### PR TITLE
feat: respect CLAUDE_CONFIG_DIR for multi-account widgets

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -11,7 +11,12 @@ const TOKEN_URL = 'https://platform.claude.com/v1/oauth/token'
 const USAGE_URL = 'https://api.anthropic.com/api/oauth/usage'
 const SCOPE = 'org:create_api_key user:profile user:inference'
 const UA = 'claude-cli/2.1.181 (external, cli)'
-const TOKEN_PATH = path.join(os.homedir(), '.claude-usage-monitor', 'auth.json')
+// when CLAUDE_CONFIG_DIR is set (e.g. via direnv for multi-account setups),
+// keep the widget's data alongside that account's Claude config
+const DATA_DIR = process.env.CLAUDE_CONFIG_DIR
+  ? path.join(process.env.CLAUDE_CONFIG_DIR, 'usage-monitor')
+  : path.join(os.homedir(), '.claude-usage-monitor')
+const TOKEN_PATH = path.join(DATA_DIR, 'auth.json')
 
 const b64url = (buf) =>
   buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')

--- a/main.js
+++ b/main.js
@@ -5,8 +5,20 @@ const os = require('node:os')
 const { getUsage } = require('./usage')
 const auth = require('./auth')
 
-// data dir: kept outside the project folder so moving the repo doesn't break it
-const DATA_DIR = path.join(os.homedir(), '.claude-usage-monitor')
+// data dir: kept outside the project folder so moving the repo doesn't break it.
+// when CLAUDE_CONFIG_DIR is set (e.g. via direnv for multi-account setups), nest
+// the widget's data under that account's Claude config dir so each account gets
+// its own auth.json, config.json, and Electron userData.
+const DATA_DIR = process.env.CLAUDE_CONFIG_DIR
+  ? path.join(process.env.CLAUDE_CONFIG_DIR, 'usage-monitor')
+  : path.join(os.homedir(), '.claude-usage-monitor')
+// when isolating per-account, also pin Electron's userData under DATA_DIR so two
+// widgets can run in parallel without fighting over cookies/cache. left untouched
+// in the default case so existing installs keep their window position etc.
+if (process.env.CLAUDE_CONFIG_DIR) {
+  fs.mkdirSync(DATA_DIR, { recursive: true })
+  app.setPath('userData', path.join(DATA_DIR, 'electron'))
+}
 // external config: edit without rebuilding the .app
 const EXTERNAL_CONFIG = path.join(DATA_DIR, 'config.json')
 // debug channel: `./pet <state>` writes here to force a state (dev only)

--- a/usage.js
+++ b/usage.js
@@ -2,7 +2,8 @@ const fs = require('node:fs')
 const path = require('node:path')
 const os = require('node:os')
 
-const PROJECTS_DIR = path.join(os.homedir(), '.claude', 'projects')
+const CLAUDE_DIR = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude')
+const PROJECTS_DIR = path.join(CLAUDE_DIR, 'projects')
 
 function labelFor(model) {
   if (!model) return 'desconhecido'


### PR DESCRIPTION
## Summary

Lets the widget piggyback on Claude Code's existing per-account convention (`CLAUDE_CONFIG_DIR`, commonly switched via direnv), so you can run one pet per account in parallel — each with its own auth, its own logs, and its own Electron state.

- `usage.js` reads logs from `$CLAUDE_CONFIG_DIR/projects` when set
- `auth.js` and `main.js` store `auth.json` / `config.json` under `$CLAUDE_CONFIG_DIR/usage-monitor` (instead of `~/.claude-usage-monitor`)
- `main.js` also re-pins Electron's `userData` under that dir, but **only** when the env var is set, so existing installs keep their window position and the default `~/Library/Application Support/claude-usage-monitor` path untouched

When `CLAUDE_CONFIG_DIR` is unset everything falls back to the original paths — zero behavior change for single-account users.

## Why

I have two Claude accounts and toggle between them via aliases like:

```bash
alias claude-a='CLAUDE_CONFIG_DIR=~/.claude         claude'
alias claude-b='CLAUDE_CONFIG_DIR=~/.claude-other   claude'
```

The widget only knew about a single account though — switching meant manually swapping `~/.claude-usage-monitor/auth.json` and losing the second account's view. With this patch, two parallel widgets just work:

```bash
alias pet-a='open -na "/Applications/Claude Usage Monitor.app"'
alias pet-b='CLAUDE_CONFIG_DIR=~/.claude-other open -na "/Applications/Claude Usage Monitor.app"'
```

Each one lands its auth/config/Electron state in a different folder and shows the right account's session %, weekly %, and token counts.

## Test plan

- [x] `bun run check` clean
- [x] `bun run pack` builds successfully
- [x] **With env var set** (`CLAUDE_CONFIG_DIR=/tmp/test bun start`): widget creates `/tmp/test/usage-monitor/electron/`, nothing leaks to `~/.claude-usage-monitor/` or `~/Library/Application Support/`
- [x] **Without env var** (`bun start`): widget uses `~/.claude-usage-monitor/` for data and `~/Library/Application Support/claude-usage-monitor/` for Electron userData — identical to pre-patch behavior
- [x] Verified two packaged `.app` instances run in parallel via `open -na`, each connected to a different Claude account

🤖 Generated with [Claude Code](https://claude.com/claude-code)