### PR TITLE
ci: automate npm + GitHub releases on push to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,15 +22,15 @@ jobs:
     if: ${{ !contains(github.event.head_commit.message, 'chore: release') }}
     runs-on: macos-latest # building a .app requires macOS
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # release-it needs full history + tags
 
       - uses: oven-sh/setup-bun@v2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version-file: .nvmrc # don't hardcode — track the pinned Node
           registry-url: https://registry.npmjs.org
 
       - run: bun install --frozen-lockfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,56 @@
+name: Release
+
+# On every push to main: figure out the next version from the Conventional
+# Commits, then (if there's something to release) bump it, build the macOS app,
+# publish to npm, and cut a GitHub Release with the .app zip attached.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write # push the release commit/tag, create the GitHub Release
+  id-token: write # npm provenance
+
+jobs:
+  release:
+    # don't re-trigger on release-it's own "chore: release" commit
+    if: ${{ !contains(github.event.head_commit.message, 'chore: release') }}
+    runs-on: macos-latest # building a .app requires macOS
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # release-it needs full history + tags
+
+      - uses: oven-sh/setup-bun@v2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - run: bun install --frozen-lockfile
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Compute next version
+        id: v
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "next=$(bunx release-it --release-version || true)" >> "$GITHUB_OUTPUT"
+
+      - name: Release
+        if: steps.v.outputs.next != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          CSC_IDENTITY_AUTO_DISCOVERY: "false" # unsigned build, skip signing
+        run: bunx release-it --ci

--- a/.release-it.json
+++ b/.release-it.json
@@ -1,6 +1,7 @@
 {
   "git": {
-    "commitMessage": "chore: release v${version}",
+    "commitMessage": "chore: release v${version} [skip ci]",
+    "commitArgs": ["--no-verify"],
     "tagName": "v${version}",
     "requireCleanWorkingDir": true,
     "requireUpstream": true
@@ -14,7 +15,7 @@
     "assets": ["dist/*.zip"]
   },
   "hooks": {
-    "before:init": ["bun run check"],
+    "before:init": ["bunx biome ci ."],
     "after:bump": ["bun run dist"]
   },
   "plugins": {

--- a/README.md
+++ b/README.md
@@ -50,34 +50,29 @@ Plus a welcome **wave** on launch. You can preview any state from the terminal w
 
 ## Install
 
-macOS (Apple Silicon).
+macOS (Apple Silicon). Two ways, depending on what you want:
 
-**Run it instantly** (no clone) — needs [Bun](https://bun.sh) or Node 24:
+### 1. Run it now — `bunx` (no install)
+
+Needs [Bun](https://bun.sh) (or use `npx` with Node 24):
 
 ```bash
 bunx claude-usage-monitor
-# or: npx claude-usage-monitor
 ```
 
-The first run downloads Electron, so give it a moment. The widget appears in the corner; quit it with the **×** button.
+The first run downloads Electron, so give it a moment. Great for trying it out — but it runs **only while that command is open** and won't start on its own. Quit it with the **×** button.
 
-**Install the real `.app`** (gets a proper app bundle that opens at login):
+### 2. Install the app — opens at login (recommended)
 
-```bash
-git clone https://github.com/renatoaug/claude-usage-monitor.git
-cd claude-usage-monitor
+For everyday use, grab the prebuilt app — no terminal needed:
 
-nvm install   # use the pinned Node version (reads .nvmrc)
-bun install   # install dependencies
+1. Download the latest **`Claude Usage Monitor-…-mac.zip`** from the [**Releases**](https://github.com/renatoaug/claude-usage-monitor/releases/latest) page.
+2. Unzip it and drag **Claude Usage Monitor.app** into `/Applications`.
+3. First open: right-click the app → **Open** → **Open** (it's unsigned).
 
-bun run pack  # → dist/mac-arm64/Claude Usage Monitor.app
-```
+It registers itself in **Login Items**, so it **starts automatically** with your Mac — set it and forget it.
 
-Drag the `.app` to `/Applications`. When run as a packaged app it registers itself in **Login Items**, so it starts with your Mac. (The `bunx` quick-run mode doesn't add a login item.)
-
-> The app is **unsigned** (personal use). If Gatekeeper complains on first open, right-click the app → **Open** → **Open**.
-
-The app keeps its data in `~/.claude-usage-monitor`, independent of how you run it.
+> The app keeps its data in `~/.claude-usage-monitor`, regardless of how you run it.
 
 ## Controls
 


### PR DESCRIPTION
## What

- **README** — two usage paths only:
  - `bunx claude-usage-monitor` — run it now (no install)
  - Download the prebuilt **.app** from Releases — opens at login (recommended)
  - Removed the clone+build steps from the user-facing install.
- **CI/CD** (`.github/workflows/main.yml`) — on push to `main`: compute the next
  version from Conventional Commits and, when there's something to release,
  build the macOS app, publish to **npm**, and create a **GitHub Release** with
  the `.app` zip attached.
- **release-it** tweaks for CI: `[skip ci]` on the release commit (no loop),
  `--no-verify` to skip the pre-commit hook, `biome ci` as the pre-check.

## Before this can publish (one-time setup)

- Add an **`NPM_TOKEN`** repo secret (an npm automation token). Without it, the
  npm publish step fails; everything else still runs.
- `GITHUB_TOKEN` is provided automatically by Actions.
- The workflow pushes the version-bump commit to `main`, so don't enable
  "require PR" branch protection on `main` without allowing this workflow to
  push (or it won't be able to commit the release).

## Notes

- macOS runner (a `.app` build needs macOS).
- First release: the version is computed from commits; if you want to control
  the very first version, run it manually once via the **workflow_dispatch**
  trigger (or locally with `bunx release-it`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)