### PR TITLE
feat: poke the pet from the CLI (clauddy <state>)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The token is saved locally (see [Data & privacy](#data--privacy)) and refreshed 
   </tr>
 </table>
 
-Plus a welcome **wave** on launch. You can preview any state from the terminal with [`./pet`](#simulate-states-pet).
+Plus a welcome **wave** on launch. You can [poke the pet from the terminal](#play-with-the-pet) too.
 
 ## Install
 
@@ -100,21 +100,24 @@ Settings saved from the UI live in `~/.claude-usage-monitor/config.json`, so you
 }
 ```
 
-## Simulate states (`./pet`)
+## Play with the pet
 
-While developing the animations, force any state from the terminal — the app watches `~/.claude-usage-monitor/debug.json` and reacts live (no rebuild needed). Run from the repo root:
+With the widget running, poke it from the terminal — just for fun:
 
 ```bash
-./pet fire        # 🔥 on fire — flames, shivers, red tint
-./pet sleeping    # 😴 sleeping — blue zzz, closed eyes, moonlight
-./pet working     # 🍴 working — eats token coins and hops
-./pet idle        # 🙂 idle — breathe + blink
-
-./pet poke        # 💕 one-shot squish + hearts
-./pet celebrate   # 🎉 one-shot jump + confetti burst
-
-./pet auto        # ↩️ release control, back to real usage data
+bunx clauddy poke        # 💕 squish + hearts
+bunx clauddy celebrate   # 🎉 jump + confetti
+bunx clauddy fire        # 🔥 on fire
+bunx clauddy sleeping    # 😴 blue zzz
+bunx clauddy working     # 🍴 eats token coins
+bunx clauddy tired       # 🥵 maxed out
+bunx clauddy idle        # 🙂 calm
+bunx clauddy auto        # ↩️ back to your real usage
 ```
+
+Each state is written to the data dir the running widget watches, so it reacts
+live. (Installed globally? Drop the `bunx`: `clauddy poke`. Working on the repo?
+`./pet <state>` does the same.)
 
 ## How it works
 
@@ -150,5 +153,3 @@ your PRs.
 
 - `feat:` → minor, `fix:` → patch, `feat!:`/`BREAKING CHANGE` → major.
 - `docs:`/`chore:`/`ci:` etc. don't trigger a release.
-- Needs an **`NPM_TOKEN`** repo secret (an npm automation token); `GITHUB_TOKEN`
-  is automatic.

--- a/bin/clauddy.js
+++ b/bin/clauddy.js
@@ -1,12 +1,59 @@
 #!/usr/bin/env node
 
-// Entry point when installed from npm / run via `bunx claude-usage-monitor`:
-// spawn the Electron runtime pointed at the app's main process.
-const { spawn } = require('node:child_process')
+// `clauddy`            → launch the widget (spawns Electron on main.js)
+// `clauddy <state>`    → poke the running widget for fun/demo (writes the state
+//                        to the data dir the app watches; the app reacts live)
 const path = require('node:path')
-const electron = require('electron')
+const fs = require('node:fs')
+const os = require('node:os')
 
-const child = spawn(electron, [path.join(__dirname, '..', 'main.js')], {
-  stdio: 'inherit',
-})
-child.on('close', (code) => process.exit(code ?? 0))
+// same data dir the app uses (respects CLAUDE_CONFIG_DIR for multi-account)
+const dataDir = process.env.CLAUDE_CONFIG_DIR
+  ? path.join(process.env.CLAUDE_CONFIG_DIR, 'usage-monitor')
+  : path.join(os.homedir(), '.claude-usage-monitor')
+
+const STATES = [
+  'fire',
+  'sleeping',
+  'working',
+  'tired',
+  'idle',
+  'poke',
+  'celebrate',
+  'auto',
+  'clear',
+]
+const arg = process.argv[2]
+
+if (!arg) {
+  // no argument → launch the app
+  const { spawn } = require('node:child_process')
+  const electron = require('electron')
+  const child = spawn(electron, [path.join(__dirname, '..', 'main.js')], { stdio: 'inherit' })
+  child.on('close', (code) => process.exit(code ?? 0))
+} else if (arg === '--help' || arg === '-h') {
+  console.log(
+    [
+      'clauddy — a cute desktop pet that tracks your Claude Code usage',
+      '',
+      'Usage:',
+      '  clauddy            launch the widget',
+      '  clauddy <state>    poke the running widget (just for fun)',
+      '',
+      'States: fire, sleeping, working, tired, idle, poke, celebrate, auto',
+      '(the widget must be running for a state to show)',
+    ].join('\n'),
+  )
+} else if (STATES.includes(arg)) {
+  // write the state for the running app to pick up
+  fs.mkdirSync(dataDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(dataDir, 'debug.json'),
+    `${JSON.stringify({ state: arg, t: Date.now() })}\n`,
+  )
+  console.log(`clauddy → ${arg} (the running widget will react)`)
+} else {
+  console.error(`clauddy: unknown command "${arg}"`)
+  console.error('try: fire, sleeping, working, tired, idle, poke, celebrate, auto — or --help')
+  process.exit(1)
+}


### PR DESCRIPTION
Lets anyone who installed via `bunx`/npm play with the pet from the terminal.

## What
- `clauddy <state>` writes the state to the data dir the running widget watches → it reacts live.
  - `bunx clauddy poke` 💕 · `celebrate` 🎉 · `fire` 🔥 · `sleeping` 😴 · `working` 🍴 · `tired` 🥵 · `idle` 🙂 · `auto` ↩️
- `clauddy` (no args) still launches the app; `--help` prints usage; unknown args error out.
- Uses the same data dir as the app (respects `CLAUDE_CONFIG_DIR`).
- README: new **Play with the pet** section; removed the internal `NPM_TOKEN` note from Releasing.

The widget must be running for a state to show. It's a fun/demo extra — normal states still come from real usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)