### PR TITLE
feat: one-command install script (no Gatekeeper hassle)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,15 +52,15 @@ Plus a welcome **wave** on launch. You can [poke the pet from the terminal](#pla
 
 macOS (Apple Silicon). Two ways, depending on what you want:
 
-### 1. Download the app — opens at login (recommended)
+### 1. Install as an app — opens at login (recommended)
 
-For everyday use, grab the prebuilt app — no terminal, no setup:
+One command — it downloads the latest release and drops it in `/Applications`:
 
-1. Download the latest **`Claude Usage Monitor-…-mac.zip`** from the [**Releases**](https://github.com/renatoaug/claude-usage-monitor/releases/latest) page.
-2. Unzip it and drag **Claude Usage Monitor.app** into `/Applications`.
-3. First open: right-click the app → **Open** → **Open** (it's unsigned).
+```bash
+curl -fsSL https://raw.githubusercontent.com/renatoaug/claude-usage-monitor/main/install.sh | bash
+```
 
-It registers itself in **Login Items**, so it **starts automatically** with your Mac — set it and forget it.
+No Gatekeeper warning: files fetched with `curl` aren't quarantined like browser downloads, so the (unsigned) app just opens. It registers itself in **Login Items**, so it **starts automatically** with your Mac — set it and forget it.
 
 ### 2. Run it via `bunx` (no install)
 
@@ -73,6 +73,19 @@ bunx clauddy
 The first run downloads Electron, so give it a moment. Handy for a quick run, but it stays up **only while that command is open** and won't start on its own. Quit it with the **×** button.
 
 > The app keeps its data in `~/.claude-usage-monitor`, regardless of how you run it.
+
+<details>
+<summary>Prefer to download the app by hand?</summary>
+
+Grab the **`…-mac.zip`** from [Releases](https://github.com/renatoaug/claude-usage-monitor/releases/latest), unzip, and drag the app to `/Applications`. The browser quarantines it, so macOS will call it *"damaged"* — clear the flag once (Terminal needs **Full Disk Access**):
+
+```bash
+xattr -dr com.apple.quarantine "/Applications/Claude Usage Monitor.app"
+```
+
+The `curl` installer above avoids all of this.
+
+</details>
 
 ## Controls
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Install Claude Usage Monitor as a native app, with no Gatekeeper hassle.
+#
+#   curl -fsSL https://raw.githubusercontent.com/renatoaug/claude-usage-monitor/main/install.sh | bash
+#
+# Files downloaded with curl aren't quarantined like browser downloads, so the
+# (unsigned, ad-hoc) app opens with a double-click — no "damaged" warning.
+set -euo pipefail
+
+REPO="renatoaug/claude-usage-monitor"
+APP_NAME="Claude Usage Monitor.app"
+DEST="/Applications"
+
+echo "→ Finding the latest release…"
+ZIP_URL="$(
+  curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" |
+    grep -oE 'https://[^"]+-mac\.zip' | head -1
+)"
+if [ -z "${ZIP_URL:-}" ]; then
+  echo "Couldn't find a macOS build in the latest release. Aborting." >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "→ Downloading…"
+curl -fSL --progress-bar "$ZIP_URL" -o "$TMP/app.zip"
+
+echo "→ Installing to ${DEST}…"
+unzip -q "$TMP/app.zip" -d "$TMP"
+rm -rf "${DEST:?}/${APP_NAME}"
+mv "$TMP/${APP_NAME}" "${DEST}/"
+
+echo "→ Launching…"
+open "${DEST}/${APP_NAME}"
+
+echo "✓ Done — Claude Usage Monitor is installed and will start at login."


### PR DESCRIPTION
Fixes the painful "damaged and can't be opened" first-run experience for the downloaded `.app`.

## The insight
That warning only happens because **browsers quarantine** downloads. **`curl` doesn't.** So a `curl | bash` installer produces a quarantine-free app that opens with a double-click — no `xattr`, no Full Disk Access, no paid notarization.

## What
- **`install.sh`** — downloads the latest release zip via curl, installs to `/Applications`, launches it. Verified: the curl-fetched app has `com.apple.quarantine` count = **0**.
- README: the recommended install is now:
  ```bash
  curl -fsSL https://raw.githubusercontent.com/renatoaug/claude-usage-monitor/main/install.sh | bash
  ```
  The manual zip download (with the `xattr -dr com.apple.quarantine` note) is kept in a collapsed `<details>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)