### PR TITLE
ci: bump actions/upload-artifact to v7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build
         run: bun run ${{ matrix.dist }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: |


### PR DESCRIPTION
Bumps `actions/upload-artifact` from v4 to v7 in the `Build (manual)` workflow — the only place it's used.

v4 targets Node 20, which GitHub deprecated; the last Build run was forced onto Node 24 with a deprecation warning. v7 runs on the current runtime and clears the warning.

No behavior change — same artifact, same paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)