### PR TITLE
fix(usage): label single-digit model versions like Opus 5

### DIFF
--- a/usage.js
+++ b/usage.js
@@ -19,10 +19,13 @@ function labelFor(model) {
           : m.includes('mythos')
             ? 'Mythos'
             : null
-  const ver = m.match(/-(\d)-(\d+)/)
-  if (fam && ver) return `${fam} ${ver[1]}.${ver[2]}`
-  if (fam) return fam
-  return model
+  if (!fam) return model
+  // version after the family: opus-5, opus-4-8, haiku-4-5-<date>
+  let ver = m.match(/(?:opus|sonnet|haiku|fable|mythos)-(\d{1,2})(?:-(\d{1,2}))?(?!\d)/)
+  // legacy ids put the version before the family: claude-3-5-sonnet
+  if (!ver) ver = m.match(/-(\d)-(\d+)/)
+  if (ver) return ver[2] ? `${fam} ${ver[1]}.${ver[2]}` : `${fam} ${ver[1]}`
+  return fam
 }
 
 function tokensOf(entry) {


### PR DESCRIPTION
## What

The **by model · 7 days** breakdown was labeling Opus 5 usage as just **"Opus"** — no version.

## Why

`labelFor()` required a two-part version (regex `/-(\d)-(\d+)/`, e.g. `-4-8`). New model ids carry a single-digit version (`claude-opus-5`, `claude-sonnet-5`, `claude-fable-5`), so they never matched and fell back to the bare family name. The usage was counted correctly — only the label was wrong.

## Fix

Match the version right after the family name with an **optional** minor:

- `claude-opus-5` → **Opus 5**
- `claude-opus-4-8` → Opus 4.8 _(unchanged)_
- `claude-sonnet-5` / `claude-fable-5` → Sonnet 5 / Fable 5
- `claude-haiku-4-5-20251001` → Haiku 4.5 _(unchanged)_
- legacy `claude-3-5-sonnet-…` → Sonnet 3.5 _(via fallback)_

Bonus: a date suffix is no longer mistaken for a minor version (`claude-sonnet-4-<date>` → **Sonnet 4**, previously `Sonnet 4.<date>`).

Lint clean (`bun run check`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)