### PR TITLE
fix(build): skip electron-builder publish so the Linux AppImage build passes

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   "scripts": {
     "start": "electron .",
     "pack": "node scripts/build-app.js --dir",
-    "dist": "node scripts/build-app.js --mac zip",
-    "dist:win": "node scripts/build-app.js --win zip",
-    "dist:linux": "node scripts/build-app.js --linux",
+    "dist": "node scripts/build-app.js --mac zip --publish never",
+    "dist:win": "node scripts/build-app.js --win zip --publish never",
+    "dist:linux": "node scripts/build-app.js --linux --publish never",
     "icon": "bash build-icon.sh",
     "gifs": "electron tools/capture/capture.js",
     "format": "biome format --write .",


### PR DESCRIPTION
## What

The manual **Build** workflow's new **Linux** job fails at the end of `electron-builder --linux`:

```
⨯ GitHub Personal Access Token is not set, neither programmatically, nor using env "GH_TOKEN"
```

([failed run](https://github.com/renatoaug/claude-usage-monitor/actions/runs/31135092629) — Windows job passes, Linux job fails.)

## Why

The AppImage target is **auto-updatable**, so electron-builder infers a GitHub publish provider from the `repository` field and tries to publish (needing a token) once the AppImage is built. macOS/Windows use plain `zip` targets, which aren't auto-updatable, so they never hit this.

Publishing in this project is owned by **semantic-release** (`@semantic-release/github` uploads the assets in `release.yml`), and the manual Build workflow explicitly never publishes. electron-builder itself should never publish.

## Fix

Pass `--publish never` to electron-builder in the `dist`, `dist:win`, and `dist:linux` scripts. This skips the publish phase outright — the AppImage/tar.gz still build and get uploaded as workflow artifacts.

## Verification

- `bun run dist` (macOS) succeeds with the flag — zip builds, exit 0.
- `bun run check` clean.
- The Linux path can only be confirmed on CI; happy to re-run the Build workflow once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
