### PR TITLE
docs: correct the AppImage filename in the install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The quickest path works the same as macOS — with [Bun](https://bun.sh) or Node
 bunx clauddy   # or: npx clauddy
 ```
 
-Prefer a standalone app? Grab the **AppImage** or **tar.gz** (`Clauddy-<version>-linux-x64.AppImage` / `Clauddy-<version>-linux-x64.tar.gz`) from the [latest release](https://github.com/renatoaug/claude-usage-monitor/releases), then:
+Prefer a standalone app? Grab the **AppImage** or **tar.gz** (`Clauddy-<version>-linux-x86_64.AppImage` / `Clauddy-<version>-linux-x64.tar.gz`) from the [latest release](https://github.com/renatoaug/claude-usage-monitor/releases), then:
 
 ```bash
 chmod +x Clauddy-*.AppImage


### PR DESCRIPTION
The first real multi-platform release (v1.12.0, from #27) shipped:

```
Clauddy-1.12.0-linux-x86_64.AppImage
Clauddy-1.12.0-linux-x64.tar.gz
Clauddy-1.12.0-mac-arm64.zip
Clauddy-1.12.0-win-x64.zip
```

electron-builder expands `${arch}` to `x86_64` for AppImage targets (and `x64` everywhere else), so the AppImage name in the README was wrong — someone copying it would not find the file. The release asset glob (`dist/*-linux-*.AppImage`) matched either way, so nothing was broken in the pipeline; only the docs were off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)