### PR TITLE
ci: assign new PRs to their author

### DIFF
--- a/.github/workflows/assign_pr.yml
+++ b/.github/workflows/assign_pr.yml
@@ -1,0 +1,22 @@
+name: Assign PR to creator
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  assign_pr:
+    name: Assign PR
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              assignees: [context.payload.pull_request.user.login],
+            });


### PR DESCRIPTION
Adds `.github/workflows/assign_pr.yml`: on `pull_request_target: [opened]`, assigns the PR to whoever opened it.

Uses `pull_request_target` so the token has write access even for PRs from forks. That trigger runs with repository permissions, but this job checks out nothing and runs no PR-authored code — it only reads `context.payload` and calls `addAssignees` — so there is no path for a fork to execute anything privileged. Permissions are scoped to `pull-requests: write`.

Note this PR itself will not be assigned automatically: the workflow has to be on the default branch before it fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)