### PR TITLE
docs: add CONTRIBUTING and issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,76 @@
+name: Bug report
+description: Something in the widget doesn't work
+labels: [bug]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened
+      description: What you did, what you saw, and what you expected instead.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - macOS (Apple Silicon)
+        - macOS (Intel)
+        - Windows (x64)
+        - Linux (x64)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install
+    attributes:
+      label: How you run it
+      description: The install path matters — each one updates and starts differently.
+      options:
+        - install.sh (the one-line installer)
+        - bunx clauddy / npx clauddy
+        - Downloaded zip / AppImage / tar.gz
+        - Built from source
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Shown on the button in ⚙ Settings.
+      placeholder: "1.12.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: connected
+    attributes:
+      label: Is your account connected?
+      description: >-
+        Percentages come from the account; token counts come from your local
+        logs. Which one is wrong narrows the cause a lot.
+      options:
+        - "Yes — logged in via ⚙ Settings"
+        - "No — token counts only"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: mode
+    attributes:
+      label: Display mode
+      options:
+        - Floating pet
+        - Menu bar / system tray
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Screenshot or anything else
+      description: >-
+        A screenshot of the widget usually says it all. Please don't paste the
+        contents of auth.json — it holds your token.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,28 @@
+name: Feature request
+description: Suggest something the pet should do
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's the problem
+      description: >-
+        The situation you're in when you'd want this — not the solution yet.
+        Clauddy already shows a lot of numbers; the useful additions are the
+        ones that answer a question you actually have mid-session.
+    validations:
+      required: true
+
+  - type: textarea
+    id: idea
+    attributes:
+      label: What you'd expect
+      description: What it would look like, or what the pet would do.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Anything you already tried or considered
+      description: Including "I just do it by hand today" — that's useful to know.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!--
+The PR title becomes the squashed commit message and drives the release, so it
+must be a Conventional Commit: feat: / fix: / docs: / chore: / ci: / test: /
+refactor: / perf: / build: / revert:
+-->
+
+## What and why
+
+<!-- What changes, and what problem it solves. Link the issue if there is one. -->
+
+Closes #
+
+## How it was verified
+
+<!-- What you actually ran or observed — not what should theoretically work. -->
+
+## Checklist
+
+- [ ] `bun run check` is clean
+- [ ] `bun run test:coverage` passes (80% overall, 60% per file, nothing shipped untested)
+- [ ] Tests cover the new behaviour
+- [ ] `bun run pack` builds and the app still launches
+- [ ] The title is a Conventional Commit with the right type
+- [ ] Docs updated if behaviour changed (`README.md` / `CLAUDE.md`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,83 @@
+# Contributing to Clauddy
+
+Thanks for helping out. This is short on purpose — it only covers the things
+that will actually trip you up.
+
+## Setup
+
+```bash
+bun install     # also wires up the pre-commit hook
+bun start       # run the widget from source
+```
+
+Node 24 (pinned in `.nvmrc`). No other setup — the app reads your existing
+`~/.claude` logs, and login is optional (without it you get token counts but no
+percentages).
+
+## Three things that will bite you
+
+**1. `bun run test`, never bare `bun test`.** The suite runs as three separate
+processes, because bun mocks are per-runtime and it loads every test file before
+running any — so `main`'s fake `electron` would reach the suites testing the
+real modules. Bare `bun test` runs all of them together and reports dozens of
+failures that have nothing to do with your change.
+
+```
+test/unit/   usage.js, auth.js, burn.js   (no mocks)
+test/main/   main.js                      (mocks electron, ./usage, ./auth)
+test/dom/    pet.js, preload.js           (happy-dom)
+```
+
+**2. Coverage is a gate, not a report.** `bun run test:coverage` fails CI under
+80% overall, under 60% for any single file, or if a file that ships in the app
+has no coverage at all. That last rule is deliberate: coverage tools only
+measure files the tests load, so a new module with no tests would otherwise
+pass green. Add a file to the app, add a test for it.
+
+**3. Your PR title becomes the commit message.** PRs are squash-merged and
+release automation reads it, so it must follow
+[Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add confetti on session reset      → minor release
+fix(auth): use the platform token host   → patch release
+docs: / chore: / ci: / test: / refactor: → no release
+```
+
+Get the type wrong and you either ship a version you didn't mean to, or ship
+nothing at all.
+
+## Before you open a PR
+
+```bash
+bun run check          # Biome format + lint; the pre-commit hook runs this too
+bun run test:coverage  # the same gate CI runs
+bun run pack           # confirm the app still builds and launches
+```
+
+## Landmines
+
+- **`main.js`'s update path spawns `curl … | bash`.** Any test that reaches
+  `do-update` must stub `child_process.spawn`, or it downloads the installer
+  and replaces the app you're running.
+- **Never commit `auth.json`.** It holds an OAuth token. It lives in
+  `~/.claude-usage-monitor/` and is gitignored — keep it that way, and don't
+  paste tokens into issues.
+- **Windows and Linux artifacts can't be cross-built from macOS.** The release
+  workflow builds each on its own runner; don't try to reproduce that locally.
+
+## Playing with the pet
+
+`./pet <state>` forces a state without waiting for real usage — handy for
+anything visual:
+
+```bash
+./pet fire        # or: sleeping, working, tired, idle, poke, celebrate
+./pet reading     # activity scenes: editing, running, planning, researching…
+./pet auto        # back to your real usage
+```
+
+## Architecture
+
+`CLAUDE.md` has the layout, the data flow, and the reasoning behind the less
+obvious decisions. Worth a skim before a first change.

--- a/README.md
+++ b/README.md
@@ -217,6 +217,11 @@ Everything lives on your machine, in `~/.claude-usage-monitor/`:
 
 Nothing leaves your machine except the OAuth calls to Anthropic's own login and usage endpoints.
 
+## Contributing
+
+Bug reports and ideas are welcome — see **[CONTRIBUTING.md](CONTRIBUTING.md)**
+for setup and the few gotchas worth knowing before a first PR.
+
 ## Dev tooling
 
 - **Bun** for install/scripts, **Node 24** pinned in `.nvmrc`


### PR DESCRIPTION
Adds `CONTRIBUTING.md`, a PR template, and bug/feature issue forms.

## Why now

The repo accumulated conventions in the last few PRs that a first-time contributor has no way to guess and will get wrong. I hit most of them myself while adding the test suite.

`CONTRIBUTING.md` deliberately covers only those, rather than restating the README:

- **`bun run test`, never bare `bun test`.** The suite is three processes, and running them together reports dozens of failures unrelated to your change — which reads as "the repo is broken", not "you ran it wrong".
- **Coverage is a gate**, including the non-obvious rule that a shipped file with *no* coverage fails, because it would otherwise pass green.
- **The PR title becomes the squashed commit** and drives semantic-release, so the Conventional Commit type decides whether anything ships, and as what.
- **The landmines**: the update path spawning `curl … | bash` in tests, `auth.json`, and the fact that Windows/Linux cannot be cross-built from macOS.

## The bug template

Asks for the things that actually narrow a diagnosis in this app rather than a generic form: platform, install path (each one updates and starts differently), version, **whether the account is connected** — percentages come from the account and token counts from local logs, so which of the two is wrong cuts the search in half — and display mode. It also warns against pasting `auth.json`, which holds a token.

## Verification

- All three YAML forms parse.
- README links to CONTRIBUTING from a new short section.
- `bun run check` clean.

Docs only, so no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)