### PR TITLE
feat: break usage down by project

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ https://github.com/user-attachments/assets/76d87b6f-2876-4000-b6db-13ba2207ae31
 - **Weekly · all models** — real % used + tokens over the last 7 days
 - **Status line** under the pet: `● working · 1.6M tok/min` (or today's tokens when idle)
 - **By model · 7 days** — Opus / Sonnet / Haiku / Fable, in tokens
+- **By project · 7 days** — which repo actually ate the week, ranked, with the tail folded into `other`
 - **30-day map** — colored squares by daily tokens (green = light → red = heavy), with the monthly total
 
-The **percentages are real**, pulled from your account (you log in once — see below). The token counts, by-model breakdown, activity status, and 30-day map come from your local logs (`~/.claude/projects/**/*.jsonl`). Everything is token-based — no dollars.
+The **percentages are real**, pulled from your account (you log in once — see below). The token counts, the by-model and by-project breakdowns, activity status, and 30-day map come from your local logs (`~/.claude/projects/**/*.jsonl`). Everything is token-based — no dollars.
 
 ## Account & live usage
 
@@ -204,7 +205,7 @@ live. (Installed globally? Drop the `bunx`: `clauddy poke`. Working on the repo?
 ## How it works
 
 - **`main.js`** — Electron main process: frameless, transparent, always-on-top window; polls usage; fires macOS notifications; watches `config.json` and `debug.json`.
-- **`usage.js`** — reads `~/.claude/projects/**/*.jsonl`, sums tokens per model/day, detects the rolling 5-hour session window, the working/sleeping status, and which activity (reading/editing/running/…) Claude is on from its latest tool use.
+- **`usage.js`** — reads `~/.claude/projects/**/*.jsonl`, sums tokens per model/project/day, detects the rolling 5-hour session window, the working/sleeping status, and which activity (reading/editing/running/…) Claude is on from its latest tool use.
 - **`auth.js`** — OAuth login (PKCE, same public client as Claude Code) that fetches the authoritative usage %. Token stored locally, never committed.
 - **`renderer/`** — the pet itself: an SVG pixel sprite, CSS animations, and the Web Animations API for particles.
 - **`make-icon.js`** — generates the app icon from the pixel sprite (`build/icon.icns`).

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -268,17 +268,23 @@
         <div class="divider"></div>
 
         <!-- by model (7 days) -->
-        <div id="bymodel">
-          <div class="bymodel-title">by model · 7 days</div>
-          <div id="bymodel-list"></div>
+        <div id="bymodel" class="sec">
+          <button class="sec-head" data-sec="bymodel" aria-expanded="true">
+            <span class="sec-name">by model · 7 days</span>
+            <svg class="sec-chev" viewBox="0 0 24 24" aria-hidden="true"><path d="M7 10l5 5 5-5" /></svg>
+          </button>
+          <div id="bymodel-list" class="sec-body"></div>
         </div>
 
         <div class="divider"></div>
 
         <!-- by project (7 days) -->
-        <div id="byproject">
-          <div class="bymodel-title">by project · 7 days</div>
-          <div id="byproject-list"></div>
+        <div id="byproject" class="sec">
+          <button class="sec-head" data-sec="byproject" aria-expanded="true">
+            <span class="sec-name">by project · 7 days</span>
+            <svg class="sec-chev" viewBox="0 0 24 24" aria-hidden="true"><path d="M7 10l5 5 5-5" /></svg>
+          </button>
+          <div id="byproject-list" class="sec-body"></div>
         </div>
 
         <div class="divider"></div>

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -275,6 +275,14 @@
 
         <div class="divider"></div>
 
+        <!-- by project (7 days) -->
+        <div id="byproject">
+          <div class="bymodel-title">by project · 7 days</div>
+          <div id="byproject-list"></div>
+        </div>
+
+        <div class="divider"></div>
+
         <!-- 30-day map -->
         <div id="heat">
           <div id="heat-row"></div>

--- a/renderer/pet.js
+++ b/renderer/pet.js
@@ -357,6 +357,14 @@ function renderHeat(days) {
 }
 
 // ranked bar list — shared by the model and project panels
+//
+// The name column is one width for the whole list, never per row: the bars are
+// only comparable if every track starts and ends at the same x. So it is sized
+// to the widest label actually present, clamped so a long path cannot squeeze
+// the bars into stubs, and anything past the clamp is clipped with an ellipsis.
+const NAME_MIN = 64
+const BAR_MIN = 96 // room left for the track and the token count
+
 function renderBars(boxId, list, limit) {
   const box = el(boxId)
   box.innerHTML = ''
@@ -369,13 +377,28 @@ function renderBars(boxId, list, limit) {
       `<span class="mname">${esc(m.label)}</span>` +
       `<span class="mbar"><i style="width:${(m.tokens / max) * 100}%"></i></span>` +
       `<span class="mval">${fmtTokens(m.tokens)}</span>`
-    // the label is truncated by CSS, so keep the full one reachable
+    // the column can clip, so keep the full label reachable
     row.firstChild.title = m.label
     box.appendChild(row)
   }
   if (!top.length) {
     box.innerHTML = '<div class="mrow" style="opacity:.5">no activity</div>'
+    return
   }
+  fitNames(box)
+}
+
+// measure the labels unconstrained, then lock the column to the widest one
+function fitNames(box) {
+  const names = [...box.querySelectorAll('.mname')]
+  // a collapsed section measures zero — it re-fits when it opens
+  if (!names.length || !box.getBoundingClientRect().width) return
+  box.style.setProperty('--name-w', 'auto')
+  let widest = 0
+  for (const n of names) widest = Math.max(widest, n.getBoundingClientRect().width)
+  const room = box.getBoundingClientRect().width - BAR_MIN
+  const w = Math.max(NAME_MIN, Math.min(Math.ceil(widest) + 1, room))
+  box.style.setProperty('--name-w', `${w}px`)
 }
 
 // by model (7 days)
@@ -656,6 +679,50 @@ window.api.onAuthResult((r) => {
   }
   fitSize()
 })
+
+// collapsible panel sections — the widget is a desktop pet, not a dashboard, so
+// each breakdown can be folded away and the choice is remembered per machine
+const SEC_KEY = 'clauddy.folded'
+
+function readFolded() {
+  try {
+    return new Set(JSON.parse(localStorage.getItem(SEC_KEY) || '[]'))
+  } catch {
+    return new Set()
+  }
+}
+
+function toggleSection(id, force) {
+  const sec = el(id)
+  if (!sec) return
+  // `folded`, not `collapsed` — the body already uses that word for the pet
+  const folded = force !== undefined ? force : !sec.classList.contains('folded')
+  sec.classList.toggle('folded', folded)
+  const head = sec.querySelector('.sec-head')
+  if (head) head.setAttribute('aria-expanded', String(!folded))
+  // the column width could not be measured while hidden
+  if (!folded) fitNames(sec.querySelector('.sec-body'))
+  // the card just changed height, and the next usage poll is seconds away —
+  // without this the window keeps its old size and clips the content
+  fitSize()
+}
+
+for (const head of document.querySelectorAll('.sec-head')) {
+  head.addEventListener('click', () => {
+    const id = head.dataset.sec
+    toggleSection(id)
+    const open = readFolded()
+    if (el(id).classList.contains('folded')) open.add(id)
+    else open.delete(id)
+    try {
+      localStorage.setItem(SEC_KEY, JSON.stringify([...open]))
+    } catch {
+      // private mode or a wiped profile — the panel just forgets, which is fine
+    }
+  })
+}
+
+for (const id of readFolded()) toggleSection(id, true)
 
 el('close').addEventListener('click', () => window.api.quit())
 el('usage').addEventListener('click', () => window.api.openUsage())

--- a/renderer/pet.js
+++ b/renderer/pet.js
@@ -141,6 +141,14 @@ const SPRITE = [
 })()
 
 // helpers
+// labels come from log fields and directory names — neither is ours to trust
+function esc(s) {
+  return String(s).replace(
+    /[&<>"']/g,
+    (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c],
+  )
+}
+
 function fmtTokens(t) {
   t = t || 0
   if (t >= 1e9) return `${(t / 1e9).toFixed(2)}B`
@@ -348,24 +356,37 @@ function renderHeat(days) {
   })
 }
 
-// by model (7 days)
-function renderModels(list) {
-  const box = el('bymodel-list')
+// ranked bar list — shared by the model and project panels
+function renderBars(boxId, list, limit) {
+  const box = el(boxId)
   box.innerHTML = ''
-  const top = list.slice(0, 4)
+  const top = list.slice(0, limit)
   const max = Math.max(1, ...top.map((m) => m.tokens))
   for (const m of top) {
     const row = document.createElement('div')
     row.className = 'mrow'
     row.innerHTML =
-      `<span class="mname">${m.label}</span>` +
+      `<span class="mname">${esc(m.label)}</span>` +
       `<span class="mbar"><i style="width:${(m.tokens / max) * 100}%"></i></span>` +
       `<span class="mval">${fmtTokens(m.tokens)}</span>`
+    // the label is truncated by CSS, so keep the full one reachable
+    row.firstChild.title = m.label
     box.appendChild(row)
   }
   if (!top.length) {
     box.innerHTML = '<div class="mrow" style="opacity:.5">no activity</div>'
   }
+}
+
+// by model (7 days)
+function renderModels(list) {
+  renderBars('bymodel-list', list, 4)
+}
+
+// by project (7 days) — usage.js already folds everything past the top few
+// into a single `other` row, so whatever arrives here is meant to be drawn
+function renderProjects(list) {
+  renderBars('byproject-list', list, 6)
 }
 
 // one-shot reaction (adds a class, removes after ms)
@@ -525,6 +546,7 @@ function render(d) {
       : `${fmtTokens(d.week.tokens)} tokens · last 7 days`
 
   renderModels(d.byModel || [])
+  renderProjects(d.byProject || [])
   renderHeat(d.days30 || [])
   el('month-total').textContent = `${fmtTokens(d.monthTokens)} tokens`
 
@@ -834,6 +856,7 @@ if (typeof module === 'object' && module.exports) {
     fmtReset,
     setState,
     renderModels,
+    renderProjects,
     renderHeat,
     showProfile,
     burn,

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -1685,7 +1685,7 @@ body.state-tired #status-text {
 .meter-top {
   display: flex;
   justify-content: space-between;
-  font-size: 10.5px;
+  font-size: 10px;
   color: var(--muted);
   margin-bottom: 4px;
 }
@@ -1722,7 +1722,7 @@ body.state-tired #status-text {
   background: linear-gradient(90deg, #e98a68, #d8442f);
 }
 
-/* by model */
+/* by model / by project */
 .bymodel-title {
   font-size: 9.5px;
   color: var(--muted);
@@ -1740,6 +1740,17 @@ body.state-tired #status-text {
 .mrow .mname {
   flex: 0 0 64px;
   font-weight: 500;
+}
+/* project names are paths, not four-letter families — give them room and clip
+   the rest, with the full name on the row's title attribute */
+#byproject .mrow {
+  font-size: 10px;
+}
+#byproject .mrow .mname {
+  flex: 0 0 126px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .mrow .mbar {
   flex: 1;

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -1722,12 +1722,44 @@ body.state-tired #status-text {
   background: linear-gradient(90deg, #e98a68, #d8442f);
 }
 
-/* by model / by project */
-.bymodel-title {
+/* by model / by project — collapsible sections */
+.sec-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0;
+  margin-bottom: 6px;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  font: inherit;
   font-size: 9.5px;
   color: var(--muted);
   letter-spacing: 0.3px;
-  margin-bottom: 6px;
+  -webkit-app-region: no-drag;
+}
+.sec-head:hover {
+  color: var(--text);
+}
+.sec-chev {
+  width: 12px;
+  height: 12px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  transition: transform 0.22s ease;
+}
+.sec.folded .sec-chev {
+  transform: rotate(-90deg);
+}
+.sec.folded .sec-body {
+  display: none;
+}
+.sec.folded .sec-head {
+  margin-bottom: 0;
 }
 .mrow {
   display: flex;
@@ -1738,19 +1770,18 @@ body.state-tired #status-text {
   margin-bottom: 5px;
 }
 .mrow .mname {
-  flex: 0 0 64px;
+  /* one width for the whole list, measured at render time — the bars are only
+     comparable if every track starts at the same x */
+  flex: 0 0 var(--name-w, 64px);
   font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 /* project names are paths, not four-letter families — give them room and clip
    the rest, with the full name on the row's title attribute */
 #byproject .mrow {
   font-size: 10px;
-}
-#byproject .mrow .mname {
-  flex: 0 0 126px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 .mrow .mbar {
   flex: 1;

--- a/test/dom/pet.test.js
+++ b/test/dom/pet.test.js
@@ -259,6 +259,27 @@ describe('the model and month panels', () => {
     expect(name.textContent).toBe('<img src=x onerror=alert(1)>')
   })
 
+  test('folds a section away and back, and says so for assistive tech', () => {
+    const sec = el('byproject')
+    const head = sec.querySelector('.sec-head')
+    expect(sec.classList.contains('folded')).toBe(false)
+
+    head.click()
+    expect(sec.classList.contains('folded')).toBe(true)
+    expect(head.getAttribute('aria-expanded')).toBe('false')
+
+    head.click()
+    expect(sec.classList.contains('folded')).toBe(false)
+    expect(head.getAttribute('aria-expanded')).toBe('true')
+  })
+
+  test('remembers which sections were folded', () => {
+    el('bymodel').querySelector('.sec-head').click()
+    expect(JSON.parse(localStorage.getItem('clauddy.folded'))).toEqual(['bymodel'])
+    el('bymodel').querySelector('.sec-head').click()
+    expect(JSON.parse(localStorage.getItem('clauddy.folded'))).toEqual([])
+  })
+
   test('draws one square per day of the month map', () => {
     const days = new Array(30).fill(0).map((_, i) => i * 1000)
     pet.renderHeat(days)

--- a/test/dom/pet.test.js
+++ b/test/dom/pet.test.js
@@ -84,6 +84,7 @@ const usage = (over = {}) => ({
   week: { pct: 0, tokens: 5000, resetMs: null },
   today: { tokens: 2000 },
   byModel: [],
+  byProject: [],
   days30: new Array(30).fill(0),
   monthTokens: 9000,
   tokensPerMin: 0,
@@ -235,6 +236,27 @@ describe('the model and month panels', () => {
     expect(rows).toContain('Opus 5')
     expect(rows).toContain('1.0M')
     expect(rows).toContain('Sonnet 5')
+  })
+
+  test('ranks projects and keeps the full name on the row', () => {
+    pet.renderProjects([
+      { label: 'claude-usage-monitor', tokens: 900_000 },
+      { label: 'other · 3', tokens: 12_000 },
+    ])
+    const rows = el('byproject-list')
+    expect(rows.children.length).toBe(2)
+    expect(rows.textContent).toContain('claude-usage-monitor')
+    expect(rows.textContent).toContain('other · 3')
+    // the column is clipped by CSS, so the untruncated label lives on the title
+    expect(rows.children[0].firstChild.title).toBe('claude-usage-monitor')
+  })
+
+  test('escapes a label instead of injecting it as markup', () => {
+    // project labels come from directory names, which are not ours to trust
+    pet.renderProjects([{ label: '<img src=x onerror=alert(1)>', tokens: 1 }])
+    const name = el('byproject-list').querySelector('.mname')
+    expect(name.querySelector('img')).toBe(null)
+    expect(name.textContent).toBe('<img src=x onerror=alert(1)>')
   })
 
   test('draws one square per day of the month map', () => {

--- a/test/unit/usage.test.js
+++ b/test/unit/usage.test.js
@@ -7,7 +7,9 @@ import path from 'node:path'
 // so the fixture root has to exist and be exported before it loads.
 const ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'clauddy-test-'))
 process.env.CLAUDE_CONFIG_DIR = ROOT
-const { getUsage, labelFor, tokensOf, detectActivity } = await import('../../usage.js')
+const { getUsage, labelFor, projectLabel, tokensOf, detectActivity } = await import(
+  '../../usage.js'
+)
 
 afterAll(() => fs.rmSync(ROOT, { recursive: true, force: true }))
 
@@ -41,8 +43,8 @@ beforeEach(() => {
   fs.rmSync(path.join(ROOT, 'projects'), { recursive: true, force: true })
 })
 
-function writeLog(lines, name = 'session.jsonl') {
-  const dir = path.join(ROOT, 'projects', `-proj-${dirSeq++}`)
+function writeLog(lines, name = 'session.jsonl', project = null) {
+  const dir = path.join(ROOT, 'projects', project ?? `-proj-${dirSeq++}`)
   fs.mkdirSync(dir, { recursive: true })
   const file = path.join(dir, name)
   fs.writeFileSync(file, `${lines.join('\n')}\n`)
@@ -131,6 +133,84 @@ describe('model labels', () => {
       { label: 'Opus 5', tokens: 150 },
       { label: 'Sonnet 5', tokens: 20 },
     ])
+  })
+})
+
+describe('project labels', () => {
+  // the directory name flattens `/` and `.` to `-`, so it cannot be reversed by
+  // string surgery — usage.js walks the real filesystem instead. These fixtures
+  // build actual directories so the walk has something true to find.
+  const enc = (p) => p.replace(/[/.]/g, '-')
+
+  test('resolves an existing path down to its basename', () => {
+    const dir = path.join(ROOT, 'fs', 'my-projects', 'claude-usage-monitor')
+    fs.mkdirSync(dir, { recursive: true })
+    expect(projectLabel(enc(dir))).toBe('claude-usage-monitor')
+  })
+
+  test('handles a dash inside a directory name', () => {
+    // `my-projects` and `my` would both start the remainder; only the longer wins
+    const dir = path.join(ROOT, 'fs', 'my', 'x')
+    fs.mkdirSync(dir, { recursive: true })
+    expect(projectLabel(enc(path.join(ROOT, 'fs', 'my-projects')))).toBe('my-projects')
+  })
+
+  test('handles a dot inside a directory name', () => {
+    const dir = path.join(ROOT, 'fs', 'nord', '.worktrees', 'sup-441')
+    fs.mkdirSync(dir, { recursive: true })
+    expect(projectLabel(enc(dir))).toBe('sup-441')
+  })
+
+  test('falls back to the raw tail when the project is gone', () => {
+    const gone = enc(path.join(ROOT, 'fs', 'my-projects', 'deleted-thing'))
+    expect(projectLabel(gone)).toContain('deleted-thing')
+  })
+
+  test('does not eat into the name of a directory that no longer exists', () => {
+    // `identity` survives, `identity-web` does not — reporting `web` would look
+    // like a real project and be the wrong one
+    fs.mkdirSync(path.join(ROOT, 'fs', 'q', 'identity'), { recursive: true })
+    const label = projectLabel(enc(path.join(ROOT, 'fs', 'q', 'identity-web')))
+    expect(label).not.toBe('web')
+    expect(label).toContain('identity-web')
+  })
+})
+
+describe('usage by project', () => {
+  test('aggregates weekly tokens per project directory', () => {
+    const a = path.join(ROOT, 'fs', 'alpha')
+    const b = path.join(ROOT, 'fs', 'beta')
+    fs.mkdirSync(a, { recursive: true })
+    fs.mkdirSync(b, { recursive: true })
+    const enc = (p) => p.replace(/[/.]/g, '-')
+    writeLog([line({ tokens: 100 }), line({ tokens: 50 })], 'session.jsonl', enc(a))
+    writeLog([line({ tokens: 20 })], 'session.jsonl', enc(b))
+    expect(getUsage(BUDGET).byProject).toEqual([
+      { label: 'alpha', tokens: 150 },
+      { label: 'beta', tokens: 20 },
+    ])
+  })
+
+  test('folds everything past the top five into one `other` row', () => {
+    for (let i = 0; i < 8; i++) {
+      writeLog([line({ tokens: 100 - i })], 'session.jsonl', `-nope-p${i}`)
+    }
+    const list = getUsage(BUDGET).byProject
+    expect(list.length).toBe(6)
+    expect(list[5].label).toBe('other · 3')
+    // 8 projects at 100-i tokens: the tail is p5+p6+p7 = 95+94+93
+    expect(list[5].tokens).toBe(95 + 94 + 93)
+  })
+
+  test('counts only the weekly window, like by-model', () => {
+    const old = path.join(ROOT, 'fs', 'stale')
+    fs.mkdirSync(old, { recursive: true })
+    writeLog(
+      [line({ ts: Date.now() - 20 * DAY, tokens: 999 })],
+      'session.jsonl',
+      old.replace(/[/.]/g, '-'),
+    )
+    expect(getUsage(BUDGET).byProject).toEqual([])
   })
 })
 

--- a/usage.js
+++ b/usage.js
@@ -28,6 +28,86 @@ function labelFor(model) {
   return fam
 }
 
+// Claude Code names each project directory after the working directory with
+// every `/` and `.` flattened to `-`, so `-Users-me-my-projects-clauddy` cannot
+// be reversed by string surgery alone: the separator and the names use the same
+// character. Instead of guessing, we walk the real filesystem and let it be the
+// dictionary — at each level we ask which actual child directory, once encoded
+// the same way, starts the remaining string. Longest match first, because `my`
+// and `my-projects` can both be candidates and only the longer one is right.
+const projectLabelCache = new Map()
+
+function encodePathSegment(name) {
+  return name.replace(/[/.]/g, '-')
+}
+
+// Walks as far as the filesystem allows and reports where it stopped. A project
+// that has since been moved or deleted still resolves its surviving ancestors,
+// which is what keeps the fallback label readable instead of a raw blob.
+//
+// `consumed` is the remainder as it stood *before* the last successful step.
+// That step is the only one that can have eaten into the name of a directory
+// that no longer exists — matching `qulture-identity` out of the encoded
+// `qulture-identity-web` leaves a bare `web`, which reads like a real project
+// and is not one. When the walk ends short, the caller rewinds to `consumed`
+// and shows a longer label rather than a confidently wrong one.
+function resolveProjectPath(dirName) {
+  let cur = path.sep
+  let rest = dirName
+  let consumed = null
+  while (rest) {
+    if (!rest.startsWith('-')) break
+    const tail = rest.slice(1)
+    let kids
+    try {
+      kids = fs.readdirSync(cur, { withFileTypes: true })
+    } catch {
+      break
+    }
+    let match = null
+    for (const k of kids) {
+      // symlinks count: /var is one on macOS, and people do symlink project trees
+      if (!k.isDirectory() && !k.isSymbolicLink()) continue
+      const enc = encodePathSegment(k.name)
+      // `my` and `my-projects` can both start the remainder — the longer one wins
+      if (tail !== enc && !tail.startsWith(`${enc}-`)) continue
+      if (!match || enc.length > encodePathSegment(match).length) match = k.name
+    }
+    if (!match) break
+    consumed = tail
+    cur = path.join(cur, match)
+    rest = tail.slice(encodePathSegment(match).length)
+  }
+  return { full: rest ? null : cur, consumed }
+}
+
+const LABEL_MAX = 26
+
+// The readable name for a project directory: its basename when the path still
+// exists, otherwise the raw tail. A moved or deleted project is shown as-is
+// rather than guessed at — a wrong name is worse than an ugly one.
+function projectLabel(dirName) {
+  const hit = projectLabelCache.get(dirName)
+  if (hit !== undefined) return hit
+  const { full, consumed } = resolveProjectPath(dirName)
+  let label
+  if (full) {
+    label = path.basename(full) || full
+  } else {
+    // whatever the filesystem could not account for, shown as-is
+    label = (consumed || dirName).replace(/^-+/, '')
+    if (label.length > LABEL_MAX) label = `…${label.slice(-(LABEL_MAX - 1))}`
+  }
+  projectLabelCache.set(dirName, label)
+  return label
+}
+
+function projectDirOf(file) {
+  const rel = path.relative(PROJECTS_DIR, file)
+  const first = rel.split(path.sep)[0]
+  return first && first !== '..' ? first : null
+}
+
 function tokensOf(entry) {
   const u = entry.usage || {}
   return (
@@ -100,6 +180,8 @@ function parseFile(full, st) {
 }
 
 const DAYS = 30
+// how many projects the panel ranks before folding the rest into `other`
+const TOP_PROJECTS = 5
 const SESSION_MS = 5 * 3600 * 1000
 
 // map a Claude Code tool name to what the pet is "doing"
@@ -213,12 +295,15 @@ function getUsage(config) {
   let weekTokens = 0
   let monthTokens = 0
   const byModel = new Map() // tokens per model, 7 days
+  const byProject = new Map() // tokens per project, 7 days
   const days30 = new Array(DAYS).fill(0) // tokens per day
   const recent = [] // last 12h, to detect the 5h session
   let last5mTokens = 0
 
   for (const f of files) {
     const entries = parseFile(f.full, f.st)
+    const dir = projectDirOf(f.full)
+    const proj = dir ? projectLabel(dir) : null
     for (const e of entries) {
       if (e.ts < start30) continue
       if (e.key && e.key !== ':' && seen.has(e.key)) continue
@@ -233,6 +318,7 @@ function getUsage(config) {
         weekTokens += t
         const lbl = labelFor(e.model)
         byModel.set(lbl, (byModel.get(lbl) || 0) + t)
+        if (proj) byProject.set(proj, (byProject.get(proj) || 0) + t)
       }
       if (e.ts >= todayMs) todayTokens += t
       if (e.ts >= recentCutoff) recent.push({ ts: e.ts, tokens: t })
@@ -277,11 +363,26 @@ function getUsage(config) {
     .map(([label, tokens]) => ({ label, tokens }))
     .sort((a, b) => b.tokens - a.tokens)
 
+  // ranked, then everything past the top N folded into one row — a machine with
+  // 40 project directories must not turn the panel into a 40-row list.
+  const ranked = [...byProject.entries()]
+    .map(([label, tokens]) => ({ label, tokens }))
+    .sort((a, b) => b.tokens - a.tokens)
+  const byProjectArr = ranked.slice(0, TOP_PROJECTS)
+  const rest = ranked.slice(TOP_PROJECTS)
+  if (rest.length) {
+    byProjectArr.push({
+      label: `other · ${rest.length}`,
+      tokens: rest.reduce((n, p) => n + p.tokens, 0),
+    })
+  }
+
   return {
     session,
     week: { tokens: weekTokens, pct: weekPct, resetMs: weekResetMs },
     today: { tokens: todayTokens },
     byModel: byModelArr,
+    byProject: byProjectArr,
     days30,
     monthTokens,
     tokensPerMin: Math.round(last5mTokens / 5),
@@ -296,4 +397,4 @@ function getUsage(config) {
 // labelFor/tokensOf/detectActivity are exported for the tests — they're the
 // parts that decode Claude Code's log format, which is the thing most likely
 // to change out from under us.
-module.exports = { getUsage, labelFor, tokensOf, detectActivity, PLAN_BUDGETS }
+module.exports = { getUsage, labelFor, projectLabel, tokensOf, detectActivity, PLAN_BUDGETS }


### PR DESCRIPTION
Closes #30.

`by project · 7 days` sits under the by-model list and ranks the repos that actually ate the week.


## The snag, and how it is handled

Claude Code names each project directory after the working directory with every `/` and `.` flattened to `-`, so `-Users-me-my-projects-clauddy` cannot be reversed by string surgery — separator and content share a character.

Rather than guess, `resolveProjectPath` walks the real filesystem and lets it be the dictionary: at each level it asks which actual child directory, once encoded the same way, starts the remaining string. Longest match first, because `my` and `my-projects` can both be candidates and only the longer one is right. Symlinks count as directories (`/var` is one on macOS). Results are cached per directory name.

Checked against all 34 project directories on my machine: every path that still exists resolves to its exact basename, including a home directory with a dot in it (`renato.ames`) and a hidden worktree dir (`.harny-worktrees`).

**When the project is gone**, the walk ends short — and the last step is the only one that can have eaten into the missing name. Matching `qulture-identity` out of `qulture-identity-web` leaves a bare `web`, which reads like a real project and is not one. A partial resolution therefore rewinds that last step and shows the longer raw tail. Uglier, never wrong.

## Also

- Everything past the top five folds into one `other · N` row, so 40 project directories do not produce a 40-row panel.
- `renderModels` is now `renderBars(boxId, list, limit)`, shared by both panels. Labels are escaped before reaching `innerHTML` — they come from directory names, which are not ours to trust — and the full label is kept on the row's `title` since the column is clipped.

## Verified

`bun run check` clean, `bun run test` green (196 tests), `bun run test:coverage` at 87.7%, `bun run pack` builds.


---

## Follow-up in this branch

Two panels of ranked bars made the widget tall enough to stop being a pet, so each breakdown now **folds from its title**, remembered in `localStorage`.

Folding changes the card height, but `fitSize()` only ran at the end of `render()` — which waits for the next usage poll — so the window kept its old size and clipped the content for a few seconds. `toggleSection()` now reports the new size immediately. Verified in Chromium (happy-dom reports `offsetHeight` 0, so a test there would pass without proving anything): folding takes the card 536 → 433 and reports 457, reopening reports 560, both matching card + the 24px margin.

The section class is `folded`, not `collapsed`, because the body already uses that word for the pet itself.

The name column was a guessed 126px — and `arielle-nutri-backoffice` measured **exactly** 126, one character from ellipsising. It is now measured from the widest label actually present, clamped so a long path cannot squeeze the bars into stubs. One width for the whole list, never per row, since the bars are only comparable if every track starts at the same x. A hidden section measures zero, so it re-fits on expand.
