### PR TITLE
fix(renderer): measure the name column in layout px

### DIFF
--- a/renderer/pet.js
+++ b/renderer/pet.js
@@ -392,12 +392,15 @@ function renderBars(boxId, list, limit) {
 function fitNames(box) {
   const names = [...box.querySelectorAll('.mname')]
   // a collapsed section measures zero — it re-fits when it opens
-  if (!names.length || !box.getBoundingClientRect().width) return
+  if (!names.length || !box.offsetWidth) return
   box.style.setProperty('--name-w', 'auto')
+  // offsetWidth, not getBoundingClientRect: the width we hand back is a layout px,
+  // so it has to be measured in layout px too. A CSS transform on an ancestor
+  // (the video stage scales the card) inflates the rect and squeezes the bars away.
   let widest = 0
-  for (const n of names) widest = Math.max(widest, n.getBoundingClientRect().width)
-  const room = box.getBoundingClientRect().width - BAR_MIN
-  const w = Math.max(NAME_MIN, Math.min(Math.ceil(widest) + 1, room))
+  for (const n of names) widest = Math.max(widest, n.offsetWidth)
+  const room = box.offsetWidth - BAR_MIN
+  const w = Math.max(NAME_MIN, Math.min(widest + 2, room))
   box.style.setProperty('--name-w', `${w}px`)
 }
 


### PR DESCRIPTION
## The bug

`fitNames()` sizes the shared name column of the **by model** / **by project** lists so every bar track starts at the same x. It measured the labels with `getBoundingClientRect()` — but wrote the answer back as `--name-w`, a layout px custom property.

Those are only the same unit when no ancestor carries a CSS transform. When one does, the rect comes back scaled while the box it feeds is not, so the column is set wider than the row it lives in: **the bars collapse to nothing and the token counts get clipped off the right edge.**

`offsetWidth` is layout px on both sides of the calculation, which is what the property wants. `Math.ceil(widest) + 1` becomes `widest + 2`, since `offsetWidth` is already integer and rounds down.

## How it showed up

The showcase recorder (`tools/showcase/record.mjs`) scales the widget to fill a 1920×1080 frame, which is exactly this condition — the `by project` panel rendered with no bars at all. Browser page zoom reaches it the same way.

The packaged app has no transform on `#card`, so shipped builds were never affected. This is a latent-correctness fix, not a user-visible regression.

## Verification

- `bun run check` clean
- `bun run test` — 198 tests green across the three groups
- Re-recorded the tour and inspected the frame at full resolution: six ranked bars, every value intact