### PR TITLE
feat(linux): show the pet icon and add a zoom setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,18 @@ chmod +x Clauddy-*.AppImage
 ./Clauddy-*.AppImage
 ```
 
+Want the pet icon to show up in your app menu / taskbar too, instead of a generic icon? Running the AppImage directly doesn't register it anywhere — GNOME (and most Wayland desktops) only pick up an app's icon from an installed `.desktop` entry. One-time setup, right next to the AppImage:
+
+```bash
+./Clauddy-*.AppImage --appimage-extract clauddy.desktop >/dev/null
+./Clauddy-*.AppImage --appimage-extract usr/share/icons/hicolor/512x512/apps/clauddy.png >/dev/null
+mkdir -p ~/.local/share/applications ~/.local/share/icons/hicolor/512x512/apps
+cp squashfs-root/usr/share/icons/hicolor/512x512/apps/clauddy.png ~/.local/share/icons/hicolor/512x512/apps/clauddy.png
+sed "s|^Exec=.*|Exec=$(readlink -f Clauddy-*.AppImage) --no-sandbox %U|" squashfs-root/clauddy.desktop > ~/.local/share/applications/clauddy.desktop
+rm -rf squashfs-root
+update-desktop-database ~/.local/share/applications 2>/dev/null
+```
+
 > The system tray icon needs an indicator extension on vanilla GNOME (e.g. "AppIndicator and KStatusNotifier Item Support") — it works out of the box on Cinnamon, KDE, and XFCE. Autostart-at-login is wired up via an XDG `.desktop` entry in `~/.config/autostart/`.
 
 > The app keeps its data in `~/.claude-usage-monitor`, regardless of platform or how you run it.

--- a/config.json
+++ b/config.json
@@ -4,6 +4,7 @@
   "alerts": true,
   "alertThresholds": [80, 95],
   "fireThreshold": 90,
+  "zoom": 100,
   "pollIntervalMs": 4000,
   "activeThresholdMs": 20000,
   "sleepThresholdMs": 300000

--- a/main.js
+++ b/main.js
@@ -65,6 +65,7 @@ function publicConfig(c) {
     alerts: c.alerts,
     alertThresholds: c.alertThresholds,
     fireThreshold: c.fireThreshold,
+    zoom: c.zoom,
   }
 }
 
@@ -78,6 +79,7 @@ function loadConfig() {
     alerts: true,
     alertThresholds: [80, 95],
     fireThreshold: 90, // session % at which the pet catches fire (tired still fixed at 100)
+    zoom: 100, // widget scale %, 100-200
     pollIntervalMs: 4000,
     activeThresholdMs: 20000,
     sleepThresholdMs: 300000,

--- a/main.js
+++ b/main.js
@@ -137,6 +137,7 @@ function createWindow() {
     skipTaskbar: true,
     hasShadow: false,
     fullscreenable: false,
+    icon: path.join(__dirname, 'build', 'icon.png'),
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -329,6 +329,22 @@
         </div>
 
         <div class="set-section">
+          <div class="set-sec-title">Zoom</div>
+          <div class="set-thresholds">
+            <span class="thr">
+              <span class="thr-cap">size</span>
+              <span class="num">
+                <input id="set-zoom" type="number" min="100" max="200" step="25" />
+                <span class="num-spin">
+                  <button type="button" class="num-btn" data-for="set-zoom" data-step="25">▲</button>
+                  <button type="button" class="num-btn" data-for="set-zoom" data-step="-25">▼</button>
+                </span>
+              </span>
+            </span>
+          </div>
+        </div>
+
+        <div class="set-section">
           <div class="set-sec-title">
             Alerts
             <input id="set-alerts" class="set-toggle" type="checkbox" aria-label="Enable alerts" />

--- a/renderer/pet.js
+++ b/renderer/pet.js
@@ -596,14 +596,24 @@ let lastW = 0
 function fitSize() {
   requestAnimationFrame(() => {
     const collapsed = document.body.classList.contains('collapsed')
-    const w = collapsed ? 140 : 276
-    const h = el('card').offsetHeight + 24 // 12px margin top + bottom
+    const zoom = Number.parseFloat(document.body.style.zoom) || 1
+    const w = (collapsed ? 140 : 276) * zoom
+    // offsetHeight never reflects a CSS zoom applied to an ancestor (confirmed
+    // empirically against this Electron build) — so measure the unzoomed content
+    // height, then scale the whole thing (content + margin) ourselves
+    const h = (el('card').offsetHeight + 24) * zoom // 12px margin top + bottom
     if (Math.abs(h - lastH) > 2 || w !== lastW) {
       lastH = h
       lastW = w
       window.api.resize(w, h)
     }
   })
+}
+
+// widget scale, applied as a CSS zoom (not transform) so offsetWidth/Height
+// keep reflecting it — see fitNames()'s comment on why transform can't be used here
+function applyZoom(z) {
+  document.body.style.zoom = (z || 100) / 100
 }
 
 let currentConfig = {}
@@ -624,6 +634,8 @@ window.api.onError((msg) => {
 window.api.onConfig((cfg) => {
   currentConfig = cfg || {}
   document.body.classList.toggle('is-menubar', currentConfig.mode === 'menubar')
+  applyZoom(currentConfig.zoom)
+  fitSize()
 })
 window.api.onRealUsage((u) => {
   realUsage = u || null
@@ -809,6 +821,7 @@ function snapshotSettings() {
     t1: el('set-t1').value,
     t2: el('set-t2').value,
     fire: el('set-fire').value,
+    zoom: el('set-zoom').value,
   })
 }
 function refreshSaveDirty() {
@@ -827,6 +840,7 @@ function populateSettings() {
   el('set-t1').value = th[0] != null ? th[0] : 80
   el('set-t2').value = th[1] != null ? th[1] : 95
   el('set-fire').value = c.fireThreshold != null ? c.fireThreshold : 90
+  el('set-zoom').value = c.zoom != null ? c.zoom : 100
   clearSaveDirty() // fields now match the saved config
 }
 function openSettings() {
@@ -850,7 +864,7 @@ for (const b of document.querySelectorAll('.num-btn')) {
   })
 }
 // light up Save whenever an editable field changes
-for (const id of ['set-alerts', 'set-t1', 'set-t2', 'set-fire']) {
+for (const id of ['set-alerts', 'set-t1', 'set-t2', 'set-fire', 'set-zoom']) {
   el(id).addEventListener('input', refreshSaveDirty)
   el(id).addEventListener('change', refreshSaveDirty)
 }
@@ -869,6 +883,9 @@ el('set-cancel').addEventListener('click', () => {
 el('set-save').addEventListener('click', () => {
   const num = (id) => parseFloat(el(id).value)
   const fire = num('set-fire')
+  const zoomRaw = num('set-zoom')
+  const zoom = zoomRaw >= 100 && zoomRaw <= 200 ? Math.round(zoomRaw) : 100
+  applyZoom(zoom) // apply immediately so the fitSize() below measures the new size
   window.api.saveConfig({
     mode: selectedMode,
     alerts: el('set-alerts').checked,
@@ -876,6 +893,7 @@ el('set-save').addEventListener('click', () => {
       .filter((n) => n >= 1 && n <= 100)
       .sort((a, b) => a - b),
     fireThreshold: fire >= 1 && fire <= 99 ? fire : 90,
+    zoom,
   })
   clearSaveDirty()
   document.body.classList.remove('settings-open')

--- a/test/dom/pet.test.js
+++ b/test/dom/pet.test.js
@@ -370,6 +370,11 @@ describe('settings and updates', () => {
     expect(document.body.classList.contains('is-menubar')).toBe(false)
   })
 
+  test('reflects the zoom it is given', () => {
+    api.handlers.onConfig({ mode: 'floating', zoom: 150 })
+    expect(document.body.style.zoom).toBe('1.5')
+  })
+
   test('surfaces an update when one is available', () => {
     api.handlers.onUpdateStatus({ state: 'available', latest: 'v9.9.9' })
     expect(document.body.textContent).toContain('9.9.9')

--- a/test/main/main.test.js
+++ b/test/main/main.test.js
@@ -497,6 +497,13 @@ describe('settings', () => {
     fire('open-usage')
     expect(opened[0]).toContain('claude.ai/settings/usage')
   })
+
+  test('persists zoom and re-broadcasts it', () => {
+    fire('save-config', { zoom: 150 })
+    expect(JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8')).zoom).toBe(150)
+    expect(lastOf('config').zoom).toBe(150)
+    fire('save-config', { zoom: 100 }) // restore default for later tests
+  })
 })
 
 describe('login', () => {

--- a/test/main/main.test.js
+++ b/test/main/main.test.js
@@ -262,6 +262,10 @@ describe('startup', () => {
     expect(loadedFile).toContain(path.join('renderer', 'index.html'))
   })
 
+  test('sets a window icon so unpackaged Linux/Windows runs are not blank', () => {
+    expect(winOptions.icon).toContain(path.join('build', 'icon.png'))
+  })
+
   test('registers every IPC channel the renderer talks on', () => {
     for (const c of [
       'resize',


### PR DESCRIPTION
## Summary
- Wire the existing `build/icon.png` pet artwork into the `BrowserWindow`, so unpackaged Linux/Windows runs show the Clauddy icon instead of Electron's default
- Add a Zoom setting (100-200%, in 25% steps) so the widget can scale up on high-DPI/small-laptop screens, applied live via CSS zoom
- Document the extra one-time step Linux/GNOME users need to register the AppImage's icon in their app menu, since GNOME only picks it up from an installed `.desktop` entry

## Test plan
- [x] `bun run check` (Biome) clean
- [x] `bun run test` — all three suites pass, including new tests for the window icon and zoom persistence/reflection
- [x] `bun run test:coverage` — 87.4%, above the 80%/60% gates
- [x] Manually verified in a real Electron window (screenshots) that zoom scales the whole card with no clipping at 200%
- [x] Built the Linux AppImage locally (`bun run dist:linux`) and confirmed the documented `.desktop`/icon registration steps make the taskbar icon show up correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FdL144wZepzahtvFrpf53