### PR TITLE
feat: show per-model weekly limits

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -152,6 +152,32 @@ function win(o) {
     : null
 }
 
+// Weekly limits scoped to one model (e.g. "Fable" on Max) live in the `limits`
+// array. The older seven_day_<model> windows are kept as a fallback for plans
+// that still report them that way.
+function scopedWeeks(j) {
+  const out = []
+  for (const l of Array.isArray(j.limits) ? j.limits : []) {
+    if (l?.kind !== 'weekly_scoped' || typeof l.percent !== 'number') continue
+    const label = l.scope?.model?.display_name
+    if (!label) continue
+    out.push({
+      label,
+      pct: l.percent,
+      resetMs: l.resets_at ? Date.parse(l.resets_at) - Date.now() : null,
+    })
+  }
+  if (out.length) return out
+  for (const [key, label] of [
+    ['seven_day_opus', 'Opus'],
+    ['seven_day_sonnet', 'Sonnet'],
+  ]) {
+    const w = win(j[key])
+    if (w) out.push({ label, ...w })
+  }
+  return out
+}
+
 // Step 3: fetch the authoritative usage
 async function fetchUsage() {
   const token = await validToken()
@@ -173,8 +199,7 @@ async function fetchUsage() {
   return {
     session: win(j.five_hour) || { pct: 0, resetMs: null },
     week: win(j.seven_day) || { pct: 0, resetMs: null },
-    sonnet: win(j.seven_day_sonnet),
-    opus: win(j.seven_day_opus),
+    scoped: scopedWeeks(j),
   }
 }
 

--- a/main.js
+++ b/main.js
@@ -95,12 +95,22 @@ function loadConfig() {
 // native notification when usage crosses a threshold
 const armed = new Set()
 function checkAlerts(config, d) {
-  if (!config.alerts || !Notification.isSupported()) return
-  const ths = config.alertThresholds || [80, 95]
-  const scopes = [
+  alertScopes(config, [
     ['session', d.session.pct],
     ['weekly usage', d.week.pct],
-  ]
+  ])
+}
+// per-model weekly limits only exist on the account side, so they're checked
+// off the OAuth poll rather than the local tick
+function checkScopedAlerts(config, u) {
+  alertScopes(
+    config,
+    (u?.scoped || []).map((s) => [`${s.label} weekly usage`, s.pct]),
+  )
+}
+function alertScopes(config, scopes) {
+  if (!config.alerts || !Notification.isSupported()) return
+  const ths = config.alertThresholds || [80, 95]
   for (const [name, pct] of scopes) {
     for (const t of ths) {
       const key = `${name}:${t}`
@@ -361,6 +371,7 @@ function updateTray() {
 function pushRealUsage(u) {
   sessionPct = u?.session ? u.session.pct : null
   updateTray()
+  checkScopedAlerts(config, u)
   if (win && !win.isDestroyed()) win.webContents.send('real-usage', u)
 }
 

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -253,6 +253,8 @@
               <div class="track"><div class="fill week" id="week-fill"></div></div>
               <div class="sub" id="week-sub">—</div>
             </div>
+            <!-- per-model weekly limits (e.g. Fable), one meter each -->
+            <div id="scoped-meters"></div>
           </div>
           <button id="limits-connect">
             <svg class="lc-ico" viewBox="0 0 24 24" aria-hidden="true">

--- a/renderer/pet.js
+++ b/renderer/pet.js
@@ -404,6 +404,27 @@ function fitNames(box) {
   box.style.setProperty('--name-w', `${w}px`)
 }
 
+// per-model weekly limits (e.g. "Fable" on Max) — one meter each, in the same
+// shape as the all-models one. The token count pairs the limit with the local
+// log totals for that model family (a "Fable" limit covers every Fable row).
+function renderScoped(list, byModel) {
+  const box = el('scoped-meters')
+  box.innerHTML = ''
+  for (const s of list) {
+    const key = s.label.toLowerCase()
+    const tokens = byModel
+      .filter((m) => m.label.toLowerCase().startsWith(key))
+      .reduce((n, m) => n + m.tokens, 0)
+    const m = document.createElement('div')
+    m.className = 'meter'
+    m.innerHTML =
+      `<div class="meter-top"><span>weekly · ${esc(key)}</span><span>${Math.round(s.pct)}%</span></div>` +
+      `<div class="track"><div class="fill week${s.pct >= 80 ? ' high' : ''}" style="width:${s.pct}%"></div></div>` +
+      `<div class="sub">${s.resetMs != null ? `resets in ${fmtReset(s.resetMs)} · ` : ''}${fmtTokens(tokens)} tokens</div>`
+    box.appendChild(m)
+  }
+}
+
 // by model (7 days)
 function renderModels(list) {
   renderBars('bymodel-list', list, 4)
@@ -571,6 +592,7 @@ function render(d) {
       ? `resets in ${fmtReset(wkReset)} · ${fmtTokens(d.week.tokens)} tokens`
       : `${fmtTokens(d.week.tokens)} tokens · last 7 days`
 
+  renderScoped(liveOn ? realUsage.scoped || [] : [], d.byModel || [])
   renderModels(d.byModel || [])
   renderProjects(d.byProject || [])
   renderHeat(d.days30 || [])

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -1679,7 +1679,8 @@ body.state-tired #status-text {
 }
 
 /* meters */
-.meter + .meter {
+.meter + .meter,
+#scoped-meters .meter {
   margin-top: 9px;
 }
 .meter-top {

--- a/test/dom/pet.test.js
+++ b/test/dom/pet.test.js
@@ -219,6 +219,44 @@ describe('the usage panel', () => {
     expect(el('week-sub').textContent).toContain('last 7 days')
   })
 
+  test('draws one meter per scoped weekly limit, with that model family tokens', () => {
+    api.handlers.onRealUsage({
+      session: { pct: 0, resetMs: null },
+      week: { pct: 10, resetMs: null },
+      scoped: [{ label: 'Fable', pct: 38, resetMs: 5 * 3600_000 }],
+    })
+    pet.render(
+      usage({
+        byModel: [
+          { label: 'Opus 5', tokens: 1_000_000 },
+          { label: 'Fable 5', tokens: 300_000 },
+          { label: 'Fable 4.9', tokens: 50_000 },
+        ],
+      }),
+    )
+    const meters = el('scoped-meters').querySelectorAll('.meter')
+    expect(meters.length).toBe(1)
+    expect(meters[0].querySelector('.meter-top').textContent).toBe('weekly · fable38%')
+    expect(meters[0].querySelector('.fill').style.width).toBe('38%')
+    expect(meters[0].querySelector('.fill').classList.contains('high')).toBe(false)
+    expect(meters[0].querySelector('.sub').textContent).toBe('resets in 5h 0m · 350.0k tokens')
+  })
+
+  test('scoped meters go high past 80% and vanish when the account has none', () => {
+    api.handlers.onRealUsage({
+      session: { pct: 0, resetMs: null },
+      week: { pct: 0, resetMs: null },
+      scoped: [{ label: 'Opus', pct: 91, resetMs: null }],
+    })
+    pet.render(usage())
+    const f = el('scoped-meters').querySelector('.fill')
+    expect(f.classList.contains('high')).toBe(true)
+    expect(el('scoped-meters').querySelector('.sub').textContent).toBe('0 tokens')
+    live(0) // no `scoped` at all
+    pet.render(usage())
+    expect(el('scoped-meters').children.length).toBe(0)
+  })
+
   test('shows a dash for the mini % until an account is connected', () => {
     api.handlers.onAuthState({ connected: false })
     pet.render(usage())

--- a/test/main/main.test.js
+++ b/test/main/main.test.js
@@ -344,6 +344,24 @@ describe('threshold alerts', () => {
     expect(bodies.some((b) => b.includes('weekly usage is over 95%'))).toBe(false)
     at(0, 0)
   })
+
+  test('per-model weekly limits alert off the OAuth poll', async () => {
+    const poll = async () => {
+      await fire('auth-code', 'code#state') // completes login → pushRealUsage
+      await new Promise((r) => realSetTimeout(r, 5))
+    }
+    const base = authState.usage
+    notifications.length = 0
+    authState.usage = { ...base, scoped: [{ label: 'Fable', pct: 82, resetMs: null }] }
+    await poll()
+    expect(notifications.length).toBe(1)
+    expect(notifications[0].body).toContain('Fable weekly usage is over 80%')
+    await poll() // still above: stays quiet
+    expect(notifications.length).toBe(1)
+    authState.usage = base // no scoped limits at all: nothing to check
+    await poll()
+    expect(notifications.length).toBe(1)
+  })
 })
 
 describe('window geometry', () => {

--- a/test/unit/auth.test.js
+++ b/test/unit/auth.test.js
@@ -153,8 +153,48 @@ describe('usage mapping', () => {
     expect(u.session.pct).toBe(42)
     expect(u.session.resetMs / 3600_000).toBeCloseTo(2, 1)
     expect(u.week.pct).toBe(7)
-    expect(u.opus).toEqual({ pct: 3, resetMs: null })
-    expect(u.sonnet).toBeNull() // absent from the payload
+    // no `limits` array: the legacy per-model windows are the fallback
+    expect(u.scoped).toEqual([{ label: 'Opus', pct: 3, resetMs: null }])
+  })
+
+  test('reads per-model weekly limits from the limits array', async () => {
+    seedToken(LIVE)
+    const resets_at = new Date(Date.now() + 24 * 3600_000).toISOString()
+    mockFetch({
+      '/oauth/usage': {
+        body: {
+          ...usageBody,
+          limits: [
+            { kind: 'session', percent: 42, resets_at },
+            { kind: 'weekly_all', percent: 7, resets_at },
+            {
+              kind: 'weekly_scoped',
+              percent: 38,
+              resets_at,
+              scope: { model: { display_name: 'Fable' } },
+            },
+            {
+              kind: 'weekly_scoped',
+              percent: 'n/a',
+              resets_at,
+              scope: { model: { display_name: 'X' } },
+            },
+            { kind: 'weekly_scoped', percent: 1, resets_at, scope: { surface: 'cowork' } }, // no model
+          ],
+        },
+      },
+    })
+    const u = await auth.fetchUsage()
+    expect(u.scoped.length).toBe(1) // the limits array wins over seven_day_opus
+    expect(u.scoped[0].label).toBe('Fable')
+    expect(u.scoped[0].pct).toBe(38)
+    expect(u.scoped[0].resetMs / 3600_000).toBeCloseTo(24, 1)
+  })
+
+  test('no scoped limits reads as an empty list', async () => {
+    seedToken(LIVE)
+    mockFetch({ '/oauth/usage': { body: { limits: 'nope' } } })
+    expect((await auth.fetchUsage()).scoped).toEqual([])
   })
 
   test('a missing window reads as zero rather than undefined', async () => {


### PR DESCRIPTION
## Summary

Closes #39.

<img width="248" alt="weekly · fable meter under weekly · all models" src="https://github.com/user-attachments/assets/082bb0df-2aef-426d-a74a-280e6f5d34e9" />

Claude Code's `/usage` shows a weekly limit scoped to one model (Fable 5 on Max). The usage API reports it in its `limits` array as `kind: "weekly_scoped"` with `scope.model.display_name`, which Clauddy ignored — it only read the top-level `five_hour` / `seven_day` windows (and parsed `seven_day_opus` / `seven_day_sonnet` without ever using them).

- **auth.js** — `scopedWeeks()` reads `weekly_scoped` entries from `limits[]`, using the model's display name as the label; falls back to the legacy `seven_day_<model>` windows. `fetchUsage()` now returns `scoped: [{ label, pct, resetMs }]` instead of the dead `opus` / `sonnet` fields.
- **renderer** — one `.meter` per scoped limit under "weekly · all models" (same style, `high` ≥ 80%), with the reset countdown and the local token total for that model family (`Fable 5` + `Fable 4.9` → "fable"). Hidden when the account has none or isn't connected.
- **main.js** — threshold alerts cover scoped limits too ("Fable weekly usage is over 80%"), checked off the OAuth poll since they only exist account-side.

## Test plan

- [x] `bun run check` clean
- [x] `bun run test` — 206 pass (5 new: `limits[]` parsing, invalid entries skipped, legacy fallback, empty list; scoped meter + family tokens, `high` state and removal; scoped alert fires once)
- [x] `bun run test:coverage` — 87.6%
- [x] `bun run pack` builds; launched the app and saw `weekly · fable 16%` under the all-models meter on a Max account
