### PR TITLE
feat(usage): show the wall-clock reset time next to the countdown

### DIFF
--- a/renderer/pet.js
+++ b/renderer/pet.js
@@ -162,6 +162,19 @@ function fmtReset(ms) {
   const m = Math.floor((ms % 3600000) / 60000)
   return h > 0 ? `${h}h ${m}m` : `${m}m`
 }
+// wall-clock time of the reset, in the machine's own locale + timezone.
+// Past 24h the day matters too, so prefix the weekday.
+function fmtResetClock(ms) {
+  if (!ms || ms <= 0) return null
+  const at = new Date(Date.now() + ms)
+  const time = at.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+  return ms >= 86400000 ? `${at.toLocaleDateString([], { weekday: 'short' })} ${time}` : time
+}
+// "2h 22m (14:35)" — countdown plus the clock time it lands on
+function fmtResetIn(ms) {
+  const at = fmtResetClock(ms)
+  return at ? `${fmtReset(ms)} (${at})` : fmtReset(ms)
+}
 // burn-rate projection lives in burn.js (shared with the tests)
 const burn = Burn.createBurnTracker()
 
@@ -420,7 +433,7 @@ function renderScoped(list, byModel) {
     m.innerHTML =
       `<div class="meter-top"><span>weekly · ${esc(key)}</span><span>${Math.round(s.pct)}%</span></div>` +
       `<div class="track"><div class="fill week${s.pct >= 80 ? ' high' : ''}" style="width:${s.pct}%"></div></div>` +
-      `<div class="sub">${s.resetMs != null ? `resets in ${fmtReset(s.resetMs)} · ` : ''}${fmtTokens(tokens)} tokens</div>`
+      `<div class="sub">${s.resetMs != null ? `resets in ${fmtResetIn(s.resetMs)} · ` : ''}${fmtTokens(tokens)} tokens</div>`
     box.appendChild(m)
   }
 }
@@ -568,7 +581,7 @@ function render(d) {
   sf.style.width = `${sessPct}%`
   sf.classList.toggle('high', sessPct >= 80)
   el('session-sub').textContent = sessActive
-    ? `resets in ${fmtReset(sessReset)} · ${fmtTokens(d.session.tokens)} tokens`
+    ? `resets in ${fmtResetIn(sessReset)} · ${fmtTokens(d.session.tokens)} tokens`
     : 'no active session'
 
   // where this pace is taking you — hidden until there's enough trail to tell
@@ -589,7 +602,7 @@ function render(d) {
   wf.classList.toggle('high', wkPct >= 80)
   el('week-sub').textContent =
     wkReset != null
-      ? `resets in ${fmtReset(wkReset)} · ${fmtTokens(d.week.tokens)} tokens`
+      ? `resets in ${fmtResetIn(wkReset)} · ${fmtTokens(d.week.tokens)} tokens`
       : `${fmtTokens(d.week.tokens)} tokens · last 7 days`
 
   renderScoped(liveOn ? realUsage.scoped || [] : [], d.byModel || [])
@@ -1006,6 +1019,7 @@ if (typeof module === 'object' && module.exports) {
     render,
     fmtTokens,
     fmtReset,
+    fmtResetIn,
     setState,
     renderModels,
     renderProjects,

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -1744,10 +1744,14 @@ body.state-tired #status-text {
 
 /* meter subtitle */
 .sub {
-  font-size: 9.5px;
+  /* small enough that "resets in 69h 15m (Fri 7:01 AM) · 1.02B tokens" stays on one line */
+  font-size: 9px;
   color: var(--muted);
   margin-top: 4px;
-  letter-spacing: 0.2px;
+  letter-spacing: 0px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* burn-rate projection — calm by default, warm when you'd run out first */

--- a/test/dom/pet.test.js
+++ b/test/dom/pet.test.js
@@ -136,6 +136,20 @@ describe('number formatting', () => {
     [45 * 60_000, '45m'],
     [3 * 3600_000 + 25 * 60_000, '3h 25m'],
   ])('%i ms → %s', (ms, s) => expect(pet.fmtReset(ms)).toBe(s))
+
+  test('the reset countdown carries the local clock time it lands on', () => {
+    const now = new Date('2026-09-01T10:00:00')
+    const realNow = Date.now
+    Date.now = () => now.getTime()
+    const at = (ms) =>
+      new Date(now.getTime() + ms).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+
+    expect(pet.fmtResetIn(2 * 3600_000)).toBe(`2h 0m (${at(2 * 3600_000)})`)
+    // past a day the weekday matters as much as the hour
+    expect(pet.fmtResetIn(69 * 3600_000)).toBe(`69h 0m (Fri ${at(69 * 3600_000)})`)
+    expect(pet.fmtResetIn(0)).toBe('now')
+    Date.now = realNow
+  })
 })
 
 describe('the pet reacts to what Claude is doing', () => {
@@ -239,7 +253,9 @@ describe('the usage panel', () => {
     expect(meters[0].querySelector('.meter-top').textContent).toBe('weekly · fable38%')
     expect(meters[0].querySelector('.fill').style.width).toBe('38%')
     expect(meters[0].querySelector('.fill').classList.contains('high')).toBe(false)
-    expect(meters[0].querySelector('.sub').textContent).toBe('resets in 5h 0m · 350.0k tokens')
+    expect(meters[0].querySelector('.sub').textContent).toMatch(
+      /^resets in 5h 0m \(.+\) · 350\.0k tokens$/,
+    )
   })
 
   test('scoped meters go high past 80% and vanish when the account has none', () => {


### PR DESCRIPTION
## What and why

"resets in 2h 22m" tells you how long you have, but not *when* — and answering "can I finish this before the window flips?" meant doing the arithmetic in your head. Each reset line now carries the wall-clock time it lands on:

```
resets in 2h 15m (12:01 PM) · 32.4M tokens
resets in 69h 15m (Fri 7:01 AM) · 1.02B tokens
```

- `fmtResetIn()` in `renderer/pet.js` wraps `fmtReset()` with the clock time, used by all three reset lines (session, weekly, and each scoped weekly meter).
- The time comes from `toLocaleTimeString([], …)` on the reset instant, so the machine's own timezone **and** format (12h/24h, locale) apply — nothing is hardcoded and nothing is configurable.
- Past 24h the hour alone is ambiguous, so the weekday is prefixed (`Fri 7:01 AM`).
- The longer text wrapped to two lines in the 252px card, so `.sub` drops to 9px with `letter-spacing: 0` and `white-space: nowrap` (+ ellipsis as a safety net for locales with wider strings). The hour is `numeric`, not `2-digit`, to save the leading zero.

## How it was verified

- `bun run check` clean
- `bun run test` — 71 dom tests pass, including a new one that freezes `Date.now` and asserts both the same-day and the past-24h (weekday-prefixed) shapes
- `bun run test:coverage` — 86.6%
- `bun run pack` builds; ran the app and checked all three meters in the real widget: one line each, at 9px still legible on the dark card

## Checklist

- [x] `bun run check` is clean
- [x] `bun run test:coverage` passes
- [x] Tests cover the new behaviour
- [x] `bun run pack` builds and the app still launches
- [x] The title is a Conventional Commit with the right type
- [x] Docs updated if behaviour changed — n/a, no documented behaviour changed
