### PR TITLE
fix(macos): ad-hoc sign the app so notifications are delivered

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,8 @@ macOS-first, with Windows (x64) support and Linux on the way.
 - `make-icon.js` — generates the macOS `.icns` from the pixel sprite
 - `make-ico.js` — packs the Windows `.ico` (`build-icon.sh` drives both + the Linux `.png`)
 - `make-tray.js` — generates the menu-bar (tray) template icon from the same sprite
+- `scripts/adhoc-sign.js` — `afterPack` hook: ad-hoc signs the macOS bundle with the
+  real appId, without which macOS silently drops the app's notifications
 - `pet` — dev script to simulate pet states (writes `~/.claude-usage-monitor/debug.json`)
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -179,11 +179,7 @@ Switching is instant — no restart. (On Windows/Linux the icon lives in the sys
 
 Optional **macOS notifications** when your session or weekly usage crosses the thresholds you set (default **80%** and **95%**) — e.g. _"Your session is over 80% — now at 82%"_. They re-arm automatically once usage drops back below a threshold (after a reset). Toggle them and edit the thresholds in **⚙ Settings**.
 
-The first alert asks macOS for permission; after that the app shows up in **System Settings > Notifications** like any other. If you built the app yourself before v0.1.1 and never saw a banner, re-sign the bundle — macOS drops notifications from an app whose code signature isn't bound to its bundle id:
-
-```bash
-codesign --force --deep --sign - --identifier app.clauddy /Applications/Clauddy.app
-```
+The first alert asks macOS for permission; after that the app shows up in **System Settings > Notifications** like any other.
 
 ## Configure (`config.json`)
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ Switching is instant — no restart. (On Windows/Linux the icon lives in the sys
 
 Optional **macOS notifications** when your session or weekly usage crosses the thresholds you set (default **80%** and **95%**) — e.g. _"Your session is over 80% — now at 82%"_. They re-arm automatically once usage drops back below a threshold (after a reset). Toggle them and edit the thresholds in **⚙ Settings**.
 
+The first alert asks macOS for permission; after that the app shows up in **System Settings > Notifications** like any other. If you built the app yourself before v0.1.1 and never saw a banner, re-sign the bundle — macOS drops notifications from an app whose code signature isn't bound to its bundle id:
+
+```bash
+codesign --force --deep --sign - --identifier app.clauddy /Applications/Clauddy.app
+```
+
 ## Configure (`config.json`)
 
 Settings saved from the UI live in `~/.claude-usage-monitor/config.json`, so you can tweak them without rebuilding:

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   },
   "build": {
     "appId": "app.clauddy",
+    "afterPack": "scripts/adhoc-sign.js",
     "productName": "Clauddy",
     "directories": {
       "output": "dist"

--- a/scripts/adhoc-sign.js
+++ b/scripts/adhoc-sign.js
@@ -1,0 +1,21 @@
+// macOS notifications are keyed off the code signature, not CFBundleIdentifier.
+// electron-builder with `identity: null` skips signing entirely, which leaves
+// Electron's own linker signature behind: identifier "Electron", Info.plist not
+// bound. macOS then never registers the app with the notification centre and
+// drops every alert in silence — the app doesn't even appear in
+// Settings > Notifications.
+//
+// An ad-hoc signature with the real bundle id fixes that and needs no developer
+// account, so it runs for every macOS build.
+const { execFileSync } = require('node:child_process')
+const path = require('node:path')
+
+exports.default = async ({ appOutDir, packager, electronPlatformName }) => {
+  if (electronPlatformName !== 'darwin') return
+  const appId = packager.appInfo.id
+  const app = path.join(appOutDir, `${packager.appInfo.productFilename}.app`)
+  execFileSync('codesign', ['--force', '--deep', '--sign', '-', '--identifier', appId, app], {
+    stdio: 'inherit',
+  })
+  console.log(`  • ad-hoc signed as ${appId} (so macOS delivers notifications)`)
+}


### PR DESCRIPTION
## What and why

Alerts never fired on macOS — no banner, and the app didn't even appear in **System Settings > Notifications**. It isn't a permission the user forgot to grant: macOS never offered one.

macOS identifies a notification-posting app by its **code signature**, not by `CFBundleIdentifier`. The `mac` build block sets `"identity": null`, so electron-builder skips signing entirely and the bundle ships with Electron's own linker signature:

```
$ codesign -dvvv /Applications/Clauddy.app
Identifier=Electron          ← not app.clauddy
Signature=adhoc (linker-signed)
Info.plist=not bound
```

With the signature unbound from the bundle, the notification centre never registers the app and drops every `new Notification().show()` in silence. `app.clauddy` was absent from `com.apple.ncprefs.plist` entirely.

`scripts/adhoc-sign.js` is an `afterPack` hook that ad-hoc signs the macOS bundle with the real appId. Ad-hoc needs no developer account or certificate, so it runs on every macOS build (CI included) and doesn't change the notarisation story — the app was already unsigned to the outside world; this only gives it a coherent identity locally.

Docs: README notes that the first alert asks for permission, and CLAUDE.md lists the new script. No manual recovery step for old builds — installing the next release is enough.

## How it was verified

- Reproduced on the installed app: no banner, no entry in `ncprefs`, `Identifier=Electron`
- Ran `codesign --force --deep --sign - --identifier app.clauddy /Applications/Clauddy.app` by hand and relaunched — macOS immediately showed the *"Clauddy" Notifications* permission prompt, and the threshold alert fired (verified by temporarily dropping `alertThresholds` to `[1]`, then restoring)
- `bun run pack` with the hook in place → `Identifier=app.clauddy`, `Info.plist entries=32`, `Signature=adhoc`
- `bun run check` clean, `bun run test` — 71 pass, `bun run test:coverage` — 86.3%

## Checklist

- [x] `bun run check` is clean
- [x] `bun run test:coverage` passes
- [ ] Tests cover the new behaviour — the hook is build-time packaging, exercised by `bun run pack` and verified with `codesign`; not reachable from the test suite
- [x] `bun run pack` builds and the app still launches
- [x] The title is a Conventional Commit with the right type
- [x] Docs updated (`README.md`, `CLAUDE.md`)
