### PR TITLE
feat(alerts): rewrite the notifications and base them on real usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,8 @@ without coverage. Runs on every PR.
 ## Data & secrets
 
 - All user data lives in `~/.claude-usage-monitor/` (NOT in the repo): `auth.json`
-  (OAuth token, mode 600), `config.json` (settings), `debug.json` (simulator).
+  (OAuth token, mode 600), `config.json` (settings), `debug.json` (simulator),
+  `alerts.json` (which notifications are already armed, so restarts don't repeat them).
 - **Never commit** `auth.json` or any token/credential. It's gitignored — keep it that way.
 
 ## Code style

--- a/README.md
+++ b/README.md
@@ -177,7 +177,19 @@ Switching is instant — no restart. (On Windows/Linux the icon lives in the sys
 
 ## Alerts
 
-Optional **macOS notifications** when your session or weekly usage crosses the thresholds you set (default **80%** and **95%**) — e.g. _"Your session is over 80% — now at 82%"_. They re-arm automatically once usage drops back below a threshold (after a reset). Toggle them and edit the thresholds in **⚙ Settings**.
+Optional **macOS notifications**, toggled (with their thresholds) in **⚙ Settings**:
+
+| Notification | When |
+| --- | --- |
+| _Session at 82%_ — `2h 39m left · resets 6:50 PM` | Your session crosses a threshold (default **80%** and **95%**) |
+| _Weekly usage at 84%_ — `resets Fri 7:00 AM` | Same, for the weekly limit |
+| _Fable weekly at 84%_ — `resets Fri 7:00 AM` | Same, for a per-model weekly limit |
+| _Session window reset_ — `full budget again` | A session you had pushed past 80% rolls over |
+| _Clauddy lost access to your usage_ | The OAuth token expired or was revoked, so the % went back to being an estimate |
+
+The last threshold you set is the only one that makes a sound; the earlier ones arrive silently. Clicking any of them brings the widget to the front. Each fires once and re-arms when usage drops back below — remembered across restarts, so relaunching at 85% doesn't repeat an alert you already dismissed.
+
+Percentages come from your account when you're logged in, and fall back to the local token estimate when you're not.
 
 The first alert asks macOS for permission; after that the app shows up in **System Settings > Notifications** like any other.
 

--- a/main.js
+++ b/main.js
@@ -603,8 +603,14 @@ ipcMain.on('save-config', (_e, patch) => {
     fs.mkdirSync(path.dirname(EXTERNAL_CONFIG), { recursive: true })
     fs.writeFileSync(EXTERNAL_CONFIG, JSON.stringify(obj, null, 2))
   } catch {}
+  const prevThresholds = String(config.alertThresholds)
   config = loadConfig()
-  armed.clear() // re-arm alerts with new thresholds
+  // re-arm only when the thresholds actually moved: saving an unrelated setting
+  // (zoom, mode…) shouldn't replay an alert the user already dismissed
+  if (String(config.alertThresholds) !== prevThresholds) {
+    armed.clear()
+    saveAlertState()
+  }
   if (doTick) doTick()
   if (win && !win.isDestroyed()) win.webContents.send('config', publicConfig(config))
   applyMode(config.mode) // switch between floating widget and menu-bar popover live

--- a/main.js
+++ b/main.js
@@ -52,6 +52,7 @@ let currentMode = 'floating' // 'floating' widget | 'menubar' popover
 let trayBounds = null // last known tray icon rect, to anchor the popover
 let lastBlurHide = 0 // debounce: ignore the tray click that dismissed the popover
 let sessionPct = null // authoritative session % shown in the tray title
+let realUsage = null // last OAuth usage payload — the % alerts trust when logged in
 let lastProgrammaticMove = 0 // ignore the 'moved' event our own setPosition triggers
 let displayChanging = 0 // ignore OS window-shuffles while a display (dis)connects
 
@@ -92,46 +93,133 @@ function loadConfig() {
   return defaults
 }
 
-// native notification when usage crosses a threshold
-const armed = new Set()
+// ---- alerts ------------------------------------------------------------------
+// One notification per (scope × threshold), re-armed when usage drops back below.
+// `armed` is persisted so relaunching at 85% doesn't repeat the 80% alert you
+// already dismissed; it also carries the last session % so a reset is detectable
+// across restarts.
+const ALERTS_FILE = path.join(DATA_DIR, 'alerts.json')
+let armed = new Set()
+let lastSessionPct = null
+function loadAlertState() {
+  try {
+    const j = JSON.parse(fs.readFileSync(ALERTS_FILE, 'utf8'))
+    armed = new Set(Array.isArray(j.armed) ? j.armed : [])
+    lastSessionPct = typeof j.lastSessionPct === 'number' ? j.lastSessionPct : null
+  } catch {} // first run, or a corrupted file: start from a clean slate
+}
+function saveAlertState() {
+  try {
+    fs.mkdirSync(DATA_DIR, { recursive: true })
+    fs.writeFileSync(ALERTS_FILE, JSON.stringify({ armed: [...armed], lastSessionPct }))
+  } catch {}
+}
+
+function fmtDuration(ms) {
+  const h = Math.floor(ms / 3600000)
+  const m = Math.floor((ms % 3600000) / 60000)
+  return h > 0 ? `${h}h ${m}m` : `${m}m`
+}
+// wall-clock time the window flips, in the machine's own locale + timezone
+function fmtClock(ms) {
+  const at = new Date(Date.now() + ms)
+  const time = at.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+  return ms >= 86400000 ? `${at.toLocaleDateString([], { weekday: 'short' })} ${time}` : time
+}
+
+function notify(title, body, { silent = true } = {}) {
+  if (!Notification.isSupported()) return
+  const n = new Notification({ title, body, silent })
+  n.on('click', showWidget) // the obvious gesture: bring the pet to the front
+  n.show()
+}
+
+// the alert lines carry the reset, since "what do I do about it" is a question
+// about time left, not about the threshold that happened to fire
+function resetLine(resetMs, withRemaining) {
+  if (resetMs == null) return ''
+  const at = `resets ${fmtClock(resetMs)}`
+  return withRemaining && resetMs > 0 ? `${fmtDuration(resetMs)} left · ${at}` : at
+}
+
+// usage crossing a threshold. `scopes` are {label, pct, resetMs, session} rows;
+// the real (OAuth) numbers are preferred over the local token estimate, which is
+// only a budget guess and can be off by an order of magnitude.
+function alertScopes(config, scopes) {
+  if (!config.alerts) return
+  const ths = config.alertThresholds || [80, 95]
+  const top = Math.max(...ths)
+  let dirty = false
+  for (const { label, pct, resetMs, session } of scopes) {
+    if (pct == null) continue
+    for (const t of ths) {
+      const key = `${label}:${t}`
+      if (pct >= t) {
+        if (!armed.has(key)) {
+          armed.add(key)
+          dirty = true
+          const urgent = t === top
+          notify(
+            `${label} at ${Math.round(pct)}%${urgent ? ' — almost out' : ''}`,
+            resetLine(resetMs, session),
+            { silent: !urgent }, // 80% is a heads-up; the last threshold earns a sound
+          )
+        }
+      } else if (armed.delete(key)) {
+        dirty = true // re-arm when it drops below
+      }
+    }
+  }
+  if (dirty) saveAlertState()
+}
+
 function checkAlerts(config, d) {
+  const r = realUsage // authoritative when logged in; the estimate is the fallback
+  const session = r?.session ?? d.session
+  const week = r?.week ?? d.week
   alertScopes(config, [
-    ['session', d.session.pct],
-    ['weekly usage', d.week.pct],
+    { label: 'Session', pct: session.pct, resetMs: session.resetMs, session: true },
+    { label: 'Weekly usage', pct: week.pct, resetMs: week.resetMs },
   ])
+  checkWindowReset(config, session.pct)
 }
 // per-model weekly limits only exist on the account side, so they're checked
 // off the OAuth poll rather than the local tick
 function checkScopedAlerts(config, u) {
   alertScopes(
     config,
-    (u?.scoped || []).map((s) => [`${s.label} weekly usage`, s.pct]),
+    (u?.scoped || []).map((s) => ({
+      label: `${s.label} weekly`,
+      pct: s.pct,
+      resetMs: s.resetMs,
+    })),
   )
 }
-function alertScopes(config, scopes) {
-  if (!config.alerts || !Notification.isSupported()) return
-  const ths = config.alertThresholds || [80, 95]
-  for (const [name, pct] of scopes) {
-    for (const t of ths) {
-      const key = `${name}:${t}`
-      if (pct >= t) {
-        if (!armed.has(key)) {
-          armed.add(key)
-          new Notification({
-            title: 'Clauddy',
-            body: `Your ${name} is over ${t}% — now at ${Math.round(pct)}%`,
-            silent: false,
-          }).show()
-        }
-      } else {
-        armed.delete(key) // re-arm when it drops below
-      }
-    }
+
+// "you can work again" — only worth saying to someone who was actually near the
+// ceiling, so a window flipping at 20% stays silent
+const RESET_FROM = 80
+const RESET_TO = 5
+function checkWindowReset(config, pct) {
+  if (pct == null) return
+  const was = lastSessionPct
+  lastSessionPct = pct
+  if (config.alerts && was != null && was >= RESET_FROM && pct <= RESET_TO) {
+    notify('Session window reset', 'full budget again')
   }
+  if (was == null || Math.round(was) !== Math.round(pct)) saveAlertState()
+}
+
+// the token going dead is a silent failure otherwise: the widget quietly falls
+// back to the local estimate and keeps showing a number the user trusts
+function alertAuthLost(config) {
+  if (!config.alerts) return
+  notify('Clauddy lost access to your usage', 'open Settings to reconnect')
 }
 
 function createWindow() {
   config = loadConfig()
+  loadAlertState()
   const { workAreaSize } = screen.getPrimaryDisplay()
   const H = 480
 
@@ -289,6 +377,16 @@ function showPopover() {
   win.focus()
 }
 
+// bring the widget to the front from wherever it is, in either mode
+function showWidget() {
+  if (!win || win.isDestroyed()) return
+  if (currentMode === 'menubar') showPopover()
+  else {
+    win.show()
+    win.focus()
+  }
+}
+
 // route every programmatic move through here so the 'moved' handler can tell
 // our own repositioning apart from a genuine user drag (and skip saving it)
 function moveWindow(x, y) {
@@ -369,6 +467,7 @@ function updateTray() {
 
 // send real usage to the renderer and refresh the tray title in one place
 function pushRealUsage(u) {
+  realUsage = u
   sessionPct = u?.session ? u.session.pct : null
   updateTray()
   checkScopedAlerts(config, u)
@@ -428,6 +527,7 @@ async function pollUsage() {
     } else if (e && e.status === 401) {
       auth.clear()
       pushRealUsage(null)
+      alertAuthLost(config)
       if (win && !win.isDestroyed()) {
         win.webContents.send('auth-state', { connected: false })
         win.webContents.send('profile', null)

--- a/test/main/main.test.js
+++ b/test/main/main.test.js
@@ -17,6 +17,7 @@ process.env.CLAUDE_CONFIG_DIR = ROOT
 const DATA_DIR = path.join(ROOT, 'usage-monitor')
 const CONFIG_PATH = path.join(DATA_DIR, 'config.json')
 const WINDOW_STATE = path.join(DATA_DIR, 'window.json')
+const ALERTS_PATH = path.join(DATA_DIR, 'alerts.json')
 
 // ---- the fake Electron -------------------------------------------------------
 const sent = [] // every webContents.send(channel, payload)
@@ -83,9 +84,22 @@ let displays = [{ bounds: { x: 0, y: 0, width: 1920, height: 1080 } }]
 class FakeNotification {
   constructor(opts) {
     this.opts = opts
+    this.handlers = new Map()
+  }
+  on(ev, cb) {
+    this.handlers.set(ev, cb)
+  }
+  get title() {
+    return this.opts.title
+  }
+  get body() {
+    return this.opts.body
+  }
+  get silent() {
+    return this.opts.silent
   }
   show() {
-    notifications.push(this.opts)
+    notifications.push(this)
   }
   static isSupported() {
     return true
@@ -158,9 +172,10 @@ let usageData = {
   ts: Date.now(),
 }
 let usageThrows = null
+const DEFAULT_USAGE = { session: { pct: 40, resetMs: 1000 }, week: { pct: 4, resetMs: null } }
 const authState = {
   connected: true,
-  usage: { session: { pct: 40, resetMs: 1000 }, week: { pct: 4, resetMs: null } },
+  usage: DEFAULT_USAGE,
   usageError: null,
   profile: { email: 'a@b.com', name: 'Ana', plan: 'Max' },
   completeError: null,
@@ -307,42 +322,116 @@ describe('startup', () => {
 })
 
 describe('threshold alerts', () => {
-  const at = (sessionPct, weekPct) => {
-    usageData = {
-      ...usageData,
-      session: { ...usageData.session, pct: sessionPct },
-      week: { ...usageData.week, pct: weekPct },
+  // the real (OAuth) numbers are what the alerts trust, so drive those: a poll
+  // refreshes them, the local tick is what evaluates the thresholds
+  const at = async (sessionPct, weekPct) => {
+    authState.usage = {
+      session: { pct: sessionPct, resetMs: 2 * 3600_000 },
+      week: { pct: weekPct, resetMs: 40 * 3600_000 },
     }
+    await fire('auth-code', 'code#state')
+    await new Promise((r) => realSetTimeout(r, 5))
     tick()
   }
 
-  test('fires once when a threshold is crossed, not on every tick', () => {
-    at(85, 0)
+  test('fires once when a threshold is crossed, not on every tick', async () => {
+    await at(85, 0)
     expect(notifications.length).toBe(1)
-    expect(notifications[0].body).toContain('session is over 80%')
+    expect(notifications[0].title).toBe('Session at 85%')
     notifications.length = 0
-    at(86, 0)
+    await at(86, 0)
     expect(notifications.length).toBe(0) // still above: stays quiet
+    await at(0, 0)
   })
 
-  test('re-arms after usage drops back below', () => {
-    at(85, 0)
+  test('re-arms after usage drops back below', async () => {
+    await at(85, 0)
     notifications.length = 0
-    at(10, 0) // reset
-    at(85, 0)
+    await at(10, 0) // reset
+    await at(85, 0)
     expect(notifications.length).toBe(1)
+    await at(0, 0)
   })
 
-  test('tracks session and weekly independently, at both levels', () => {
-    at(0, 0)
+  test('tracks session and weekly independently, at both levels', async () => {
+    await at(0, 0)
     notifications.length = 0
-    at(96, 81)
-    const bodies = notifications.map((n) => n.body)
-    expect(bodies.some((b) => b.includes('session is over 80%'))).toBe(true)
-    expect(bodies.some((b) => b.includes('session is over 95%'))).toBe(true)
-    expect(bodies.some((b) => b.includes('weekly usage is over 80%'))).toBe(true)
-    expect(bodies.some((b) => b.includes('weekly usage is over 95%'))).toBe(false)
-    at(0, 0)
+    await at(96, 81)
+    const titles = notifications.map((n) => n.title)
+    expect(titles).toContain('Session at 96%')
+    expect(titles).toContain('Session at 96% — almost out') // the top threshold
+    expect(titles).toContain('Weekly usage at 81%')
+    expect(titles.some((t) => t.startsWith('Weekly usage at 81% —'))).toBe(false)
+    await at(0, 0)
+  })
+
+  test('only the top threshold makes a sound, and the reset is in the body', async () => {
+    await at(0, 0)
+    notifications.length = 0
+    await at(96, 0)
+    const [first, second] = notifications
+    expect(first.silent).toBe(true) // 80%: a heads-up
+    expect(second.silent).toBe(false) // 95%: urgency
+    expect(first.body).toMatch(/^2h 0m left · resets /) // the session line carries time left
+    await at(0, 0)
+  })
+
+  test('the weekly line carries only the reset, with the weekday', async () => {
+    await at(0, 0)
+    notifications.length = 0
+    await at(0, 85)
+    expect(notifications[0].body).toMatch(/^resets \w{3} /)
+    await at(0, 0)
+  })
+
+  test('clicking a notification brings the widget to the front', async () => {
+    await at(0, 0)
+    notifications.length = 0
+    await at(85, 0)
+    winMock.visible = false
+    notifications[0].handlers.get('click')()
+    expect(winMock.visible).toBe(true)
+    await at(0, 0)
+  })
+
+  test('announces a window reset only to someone who was near the ceiling', async () => {
+    await at(85, 0)
+    notifications.length = 0
+    await at(0, 0) // the window flipped
+    expect(notifications.map((n) => n.title)).toContain('Session window reset')
+    notifications.length = 0
+    await at(20, 0) // nowhere near the ceiling…
+    await at(0, 0) // …so its reset says nothing
+    expect(notifications.length).toBe(0)
+  })
+
+  test('the armed set survives a restart, so an alert is not repeated', async () => {
+    await at(85, 0)
+    expect(JSON.parse(fs.readFileSync(ALERTS_PATH, 'utf8')).armed).toContain('Session:80')
+    await at(0, 0)
+    expect(JSON.parse(fs.readFileSync(ALERTS_PATH, 'utf8')).armed).not.toContain('Session:80')
+  })
+
+  test('falls back to the local estimate when nobody is logged in', () => {
+    fire('auth-logout')
+    notifications.length = 0
+    usageData = { ...usageData, session: { ...usageData.session, pct: 85 } }
+    tick()
+    expect(notifications[0].title).toBe('Session at 85%')
+    usageData = { ...usageData, session: { ...usageData.session, pct: 0 } }
+    tick()
+  })
+
+  test('losing the token says so, instead of failing silently', async () => {
+    await fire('auth-code', 'code#state') // connected, and a poll is scheduled
+    await new Promise((r) => realSetTimeout(r, 5))
+    notifications.length = 0
+    authState.usageError = Object.assign(new Error('dead'), { status: 401 })
+    await timers.timeouts.at(-1).fn() // the scheduled poll, now rejected
+    await new Promise((r) => realSetTimeout(r, 5))
+    expect(notifications.map((n) => n.title)).toContain('Clauddy lost access to your usage')
+    authState.usageError = null
+    authState.connected = true
   })
 
   test('per-model weekly limits alert off the OAuth poll', async () => {
@@ -350,17 +439,19 @@ describe('threshold alerts', () => {
       await fire('auth-code', 'code#state') // completes login → pushRealUsage
       await new Promise((r) => realSetTimeout(r, 5))
     }
-    const base = authState.usage
+    const base = { session: { pct: 0, resetMs: 1000 }, week: { pct: 0, resetMs: null } }
     notifications.length = 0
     authState.usage = { ...base, scoped: [{ label: 'Fable', pct: 82, resetMs: null }] }
     await poll()
     expect(notifications.length).toBe(1)
-    expect(notifications[0].body).toContain('Fable weekly usage is over 80%')
+    expect(notifications[0].title).toBe('Fable weekly at 82%')
     await poll() // still above: stays quiet
     expect(notifications.length).toBe(1)
     authState.usage = base // no scoped limits at all: nothing to check
     await poll()
     expect(notifications.length).toBe(1)
+    authState.usage = DEFAULT_USAGE // leave the shared fixture as we found it
+    await poll()
   })
 })
 

--- a/test/main/main.test.js
+++ b/test/main/main.test.js
@@ -434,6 +434,34 @@ describe('threshold alerts', () => {
     authState.connected = true
   })
 
+  test('editing the thresholds re-arms the alerts, on disk too', async () => {
+    await at(85, 0)
+    expect(JSON.parse(fs.readFileSync(ALERTS_PATH, 'utf8')).armed).toContain('Session:80')
+    fire('save-config', { alertThresholds: [70, 95] })
+    expect(JSON.parse(fs.readFileSync(ALERTS_PATH, 'utf8')).armed).not.toContain('Session:80')
+    fire('save-config', { alertThresholds: [80, 95] })
+    await at(0, 0)
+  })
+
+  test('saving an unrelated setting does not replay a dismissed alert', async () => {
+    await at(85, 0)
+    notifications.length = 0
+    fire('save-config', { zoom: 125 })
+    expect(notifications.length).toBe(0)
+    fire('save-config', { zoom: 100 })
+    await at(0, 0)
+  })
+
+  test('turning alerts off silences every kind', async () => {
+    await at(0, 0)
+    fire('save-config', { alerts: false })
+    notifications.length = 0
+    await at(96, 96)
+    await at(0, 0) // would also be a window reset
+    expect(notifications.length).toBe(0)
+    fire('save-config', { alerts: true })
+  })
+
   test('per-model weekly limits alert off the OAuth poll', async () => {
     const poll = async () => {
       await fire('auth-code', 'code#state') // completes login → pushRealUsage


### PR DESCRIPTION
## What and why

The alerts were saying the wrong thing, in the wrong words, at the wrong moments. A banner reading _"Your weekly usage is over 1% — now at 28%"_ landed while the widget right below it showed **2%**.

**The numbers were wrong.** `checkAlerts` read `d.session.pct` / `d.week.pct` from `usage.js` — local token counts divided by a budget guessed in `config.json` (`max5x: week 3450e6`). The panel, meanwhile, shows the authoritative % from the account API. Two different answers to the same question, and the notification was quoting the worse one. Alerts now prefer the OAuth numbers whenever you're logged in and fall back to the estimate only when you're not — which is what the per-model alerts already did.

**The copy said nothing useful.** `Clauddy` / `Your session is over 80% — now at 82%` states the threshold that fired (which you configured, so you know it) and repeats itself. The title now carries the fact and the body carries what you'd act on — the time left:

| | Before | After |
| --- | --- | --- |
| Session · 80% | `Clauddy` / `Your session is over 80% — now at 82%` | `Session at 82%` / `2h 39m left · resets 6:50 PM` |
| Session · 95% | `Clauddy` / `Your session is over 95% — now at 96%` | `Session at 96% — almost out` / `2h 39m left · resets 6:50 PM` |
| Weekly · 80% | `Clauddy` / `Your weekly usage is over 80% — now at 84%` | `Weekly usage at 84%` / `resets Fri 7:00 AM` |
| Per-model · 80% | `Clauddy` / `Your Fable weekly usage is over 80% — now at 84%` | `Fable weekly at 84%` / `resets Fri 7:00 AM` |

The reset line reuses the wall-clock format the widget got in #42.

**Two new notifications**, both for things you currently can't see:

- **`Session window reset`** / `full budget again` — fires only if you'd pushed that window past 80%, so a window flipping at 20% stays silent. It's the "you can work again" signal for someone who hit the ceiling.
- **`Clauddy lost access to your usage`** / `open Settings to reconnect` — the token expiring is a silent failure today: the widget drops back to the local estimate and you keep trusting a number that changed meaning. Only on the background poll's 401, never during a login you're actively doing (the UI already shows that error).

**Three behaviour fixes:**

- `armed` is persisted to `~/.claude-usage-monitor/alerts.json`, so relaunching at 85% no longer repeats the 80% alert you already dismissed. It still re-arms when usage drops below.
- Only the top threshold makes a sound. 80% is a heads-up, 95% is urgency — they shouldn't arrive the same way.
- Clicking a notification brings the widget to the front (in both floating and menu-bar mode).
- `save-config` re-arms the alerts only when `alertThresholds` actually changed, and now persists that reset. It used to clear the in-memory set on *every* save (so nudging the zoom replayed an 80% alert you had dismissed) while leaving the file untouched (so a restart resurrected the stale state).

## Key decisions

**Fall back to the estimate instead of staying quiet when logged out.** A wrong-ish alert is still better than none for someone who never connected an account — that's the mode the app shipped in originally. The fallback is only reached when `realUsage` is null, and logout clears it.

**The window-reset alert is gated on `was >= 80 && now <= 5`, not on `resetMs` flipping.** The reset instant is known, but firing on it would notify everyone every five hours regardless of whether they cared. Gating on where you *were* makes it a message to the person who was blocked.

**`armed` persists as a plain key list, not as timestamps.** The keys are self-invalidating: the next tick below the threshold deletes them. So a window that resets while the app is closed heals on the first poll after launch, with no clock arithmetic.

**Sound is keyed to `t === Math.max(thresholds)`, not to a hardcoded 95.** The thresholds are user-editable; someone who sets `[50, 70]` should still get one quiet alert and one loud one.

## How it was verified

- `bun run test` — 54 main-process tests (13 new/rewritten in the alerts suite): copy of every alert, silent vs. sounding, reset line format for session vs. weekly, click focusing the widget, window-reset gating in both directions, `alerts.json` gaining and losing a key, the logged-out fallback, and the 401 notification firing off the poll but not off a login
- Settings paths covered too: editing the thresholds clears `alerts.json`, saving an unrelated setting doesn't, and `alerts: false` silences every kind including the window reset
- `bun run test:coverage` — 87.4%
- `bun run check` clean, `bun run pack` builds

## Checklist

- [x] `bun run check` is clean
- [x] `bun run test:coverage` passes
- [x] Tests cover the new behaviour
- [x] `bun run pack` builds and the app still launches
- [x] The title is a Conventional Commit with the right type
- [x] Docs updated (`README.md` alerts table, `CLAUDE.md` data dir)
