### PR TITLE
fix(accounts): keep the switcher reachable and stop cross-labeling

### DIFF
--- a/main.js
+++ b/main.js
@@ -678,16 +678,32 @@ function startUsagePoll() {
 }
 
 // push the logged-in account's identity (email + plan) to the renderer
-async function sendProfile() {
+let profileTimer = null
+async function sendProfile(tries = 0) {
+  clearTimeout(profileTimer)
   if (!auth.isConnected()) return
+  // whose profile this is, decided *before* the await: a switch during the
+  // fetch would otherwise label the new account with the old one's email
+  const id = accounts.activeId()
   try {
     const p = await auth.fetchProfile()
+    if (id !== accounts.activeId()) return // switched under us — this is stale
     if (p?.email) {
-      accounts.label(accounts.activeId(), p.email) // a better name than "acct-xyz"
+      accounts.label(id, p.email) // a better name than "acct-xyz"
       sendAccounts()
     }
     if (win && !win.isDestroyed()) win.webContents.send('profile', p)
-  } catch {} // non-fatal: the chip just stays hidden
+  } catch {
+    // a rate limit or a blip would otherwise hide the chip — and with it the
+    // account switcher — until the app is restarted, so keep trying for a while
+    if (tries >= 4) return
+    profileTimer = setTimeout(
+      () => {
+        if (id === accounts.activeId()) sendProfile(tries + 1)
+      },
+      30 * 1000 * 2 ** tries,
+    )
+  }
 }
 
 // begin() has to run *after* any account switch: switching resets the pending

--- a/renderer/pet.js
+++ b/renderer/pet.js
@@ -700,26 +700,38 @@ window.api.onAuthState((s) => {
 })
 
 // logged-in account chip (email + plan) shown top-left when connected
+let lastProfile = null
 function showProfile(p) {
+  lastProfile = p
+  paintChip()
+}
+
+// The chip is also the account switcher, so it must not vanish just because the
+// profile fetch failed — that would strand the user on one account until a
+// restart. The label main stored for the active account is the same email, so
+// it stands in until the profile lands.
+function paintChip() {
+  const p = lastProfile
+  const a = lastAccounts
+  const active = (a?.accounts || []).find((x) => x.id === a?.active)
+  const email = p?.email || (active?.connected ? active.label : null)
   // the settings line says who is connected, not just that someone is
-  el('acc-ok').textContent = p?.email
-    ? `● ${p.email}${p.plan ? ` · ${p.plan}` : ''}`
-    : '● Connected'
+  el('acc-ok').textContent = email ? `● ${email}${p?.plan ? ` · ${p.plan}` : ''}` : '● Connected'
   const chip = el('account-chip')
   const mini = el('mini-acct')
-  if (!p?.email) {
+  if (!email) {
     chip.hidden = true
     mini.hidden = true
     return
   }
   // expanded: full email chip in the top bar
-  el('ac-email').textContent = p.email
-  chip.title = p.name ? `${p.name} · ${p.email}` : p.email
-  setPlan(el('ac-plan'), p.plan)
+  el('ac-email').textContent = email
+  chip.title = p?.name ? `${p.name} · ${email}` : email
+  setPlan(el('ac-plan'), p?.plan)
   chip.hidden = false
   // collapsed: short name + plan in the mini block (email won't fit at 116px)
-  el('mini-acct-name').textContent = p.name || p.email.split('@')[0]
-  setPlan(el('mini-acct-plan'), p.plan)
+  el('mini-acct-name').textContent = p?.name || email.split('@')[0]
+  setPlan(el('mini-acct-plan'), p?.plan)
   mini.hidden = false
 }
 function setPlan(node, plan) {
@@ -765,6 +777,8 @@ function accountRow(acc, a) {
 function renderAccounts(a) {
   lastAccounts = a
   document.body.classList.toggle('one-account', (a?.accounts || []).length < 2)
+  paintChip() // the label may be all the chip has to go on
+
   if (el('acc-menu').hidden) return
   // the switch is done: the chip now names the account the menu was pointing at
   if (switching && !a?.busy) closeAccountMenu()

--- a/test/dom/pet.test.js
+++ b/test/dom/pet.test.js
@@ -379,7 +379,28 @@ describe('the account chip', () => {
   })
 
   test('hides itself when there is no account', () => {
+    api.handlers.onAccounts({ active: 'default', accounts: [] })
     pet.showProfile(null)
+    expect(el('account-chip').hidden).toBe(true)
+  })
+
+  test('falls back to the account label when the profile never arrives', () => {
+    pet.showProfile(null)
+    api.handlers.onAccounts({
+      active: 'default',
+      accounts: [{ id: 'default', label: 'ana@example.com', connected: true }],
+    })
+    expect(el('account-chip').hidden).toBe(false)
+    expect(el('ac-email').textContent).toBe('ana@example.com')
+    expect(el('mini-acct-name').textContent).toBe('ana')
+  })
+
+  test('a listed but disconnected account gets no chip', () => {
+    pet.showProfile(null)
+    api.handlers.onAccounts({
+      active: 'default',
+      accounts: [{ id: 'default', label: 'ana@example.com', connected: false }],
+    })
     expect(el('account-chip').hidden).toBe(true)
   })
 })

--- a/test/main/main.test.js
+++ b/test/main/main.test.js
@@ -214,7 +214,13 @@ mock.module('../../auth.js', () => ({
     if (authState.usageError) throw authState.usageError
     return authState.usage
   },
-  fetchProfile: async () => authState.profile,
+  fetchProfile: async () => {
+    const p = authState.profile // captured before the wait, like the real fetch
+    if (authState.profileDelay) {
+      await new Promise((r) => realSetTimeout(r, authState.profileDelay))
+    }
+    return p
+  },
   clear: () => {
     authState.cleared++
     authState.connected = false
@@ -834,6 +840,26 @@ describe('accounts', () => {
     await fire('auth-code', 'code#state')
     await new Promise((r) => realSetTimeout(r, 5))
     expect(listed().accounts.at(-1).label).toBe('a@b.com')
+  })
+
+  test('a profile arriving after a switch does not relabel the new account', async () => {
+    fire('accounts-add')
+    const id = listed().active
+    await fire('auth-code', 'code#state')
+    await new Promise((r) => realSetTimeout(r, 5))
+    expect(listed().accounts.find((a) => a.id === id).label).toBe('a@b.com')
+
+    // leave for `default` with its profile fetch still in flight…
+    authState.profile = { email: 'other@b.com' }
+    authState.profileDelay = 40
+    fire('accounts-switch', 'default')
+    await new Promise((r) => realSetTimeout(r, 5))
+    // …and come back before it lands: it belongs to `default`, not to us
+    authState.profile = { email: 'a@b.com' }
+    authState.profileDelay = 0
+    fire('accounts-switch', id)
+    await new Promise((r) => realSetTimeout(r, 80))
+    expect(listed().accounts.find((a) => a.id === id).label).toBe('a@b.com')
   })
 
   test('removing an account takes its data dir with it', async () => {


### PR DESCRIPTION
Two bugs reported against 1.21, both rooted in `sendProfile()`.

### The email chip disappeared, taking the switcher with it

The chip only rendered if `auth.fetchProfile()` succeeded, and a failure was swallowed (`catch {}`) with no retry. A rate limit or a network blip therefore hid the chip until the next launch — and since the chip *is* the account switcher, there was no way to change accounts short of restarting the app.

- the fetch now retries with a backoff (30s, doubling, 5 attempts)
- the chip falls back to the label main already stored for the active account, so the switcher stays reachable even if the profile never lands. Only for an account that actually holds a token — a disconnected one still gets no chip.

### Two accounts showing the same email

`sendProfile()` read `accounts.activeId()` *after* the await, so switching while a fetch was in flight stamped the old account's email onto the new one. The id is now pinned before the await and a stale answer is dropped.

### Tests

- `test/main`: a profile arriving after a switch must not relabel the new account. Verified it fails against the old code and passes against the new.
- `test/dom`: the chip falls back to the label, and stays hidden for a listed but disconnected account.

`bun run test` 107/67/91 pass · coverage 90.1% · `bun run check` clean · `bun run pack` builds.