### PR TITLE
fix(auth): survive a sleep without asking for a new login

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -35,12 +35,25 @@ function setDataDir(dir) {
   tokens = null
   profile = null
   pending = null
+  unreadable = false
 }
 
+// Set when the file itself could not be read for a reason other than "it is not
+// there" — a disk still waking up, say. That must not read as a logout, or the
+// widget asks for a login it doesn't need and every account looks gone. A file
+// we did read but cannot parse is a different matter: that one really is dead.
+let unreadable = false
 function load() {
   if (tokens) return tokens
+  let raw = null
   try {
-    tokens = JSON.parse(fs.readFileSync(tokenPath, 'utf8'))
+    raw = fs.readFileSync(tokenPath, 'utf8')
+    unreadable = false
+  } catch (e) {
+    unreadable = e?.code !== 'ENOENT'
+  }
+  try {
+    tokens = raw == null ? null : JSON.parse(raw)
   } catch {
     tokens = null
   }
@@ -56,12 +69,15 @@ function save(t) {
 function clear() {
   tokens = null
   profile = null
+  unreadable = false
   try {
     fs.unlinkSync(tokenPath)
   } catch {}
 }
 function isConnected() {
-  return !!load()
+  // a token we merely failed to read still counts: the account is connected,
+  // we just couldn't see it this instant
+  return !!load() || unreadable
 }
 
 // Step 1: build the authorize URL (opens in the browser)
@@ -152,7 +168,13 @@ async function refresh() {
 
 async function validToken() {
   const t = load()
-  if (!t) throw Object.assign(new Error('not connected'), { status: 401 })
+  // status 0 is "try again later", not "log in again": only a token that is
+  // genuinely absent should send the user back through the browser
+  if (!t) {
+    throw Object.assign(new Error(unreadable ? 'token unreadable' : 'not connected'), {
+      status: unreadable ? 0 : 401,
+    })
+  }
   if (!t.expires_at || t.expires_at - Date.now() < 60000) await refresh()
   return load().access_token
 }

--- a/main.js
+++ b/main.js
@@ -8,6 +8,7 @@ const {
   Tray,
   Menu,
   nativeImage,
+  powerMonitor,
 } = require('electron')
 const path = require('node:path')
 const fs = require('node:fs')
@@ -336,6 +337,7 @@ function createWindow() {
   for (const a of accounts.list()) pruneEmpty(a.id)
   accounts.pruneOrphans() // folders those slots left behind
   applyAccount(accounts.active())
+  powerMonitor?.on?.('resume', onResume)
   const { workAreaSize } = screen.getPrimaryDisplay()
   const H = 480
 
@@ -648,6 +650,7 @@ function watchDebug() {
 // ---- real usage via OAuth (authoritative %), polled slowly with 429 backoff ----
 let usageTimer = null
 let usageBackoff = 5 * 60 * 1000
+let authFails = 0 // consecutive 401s — see pollUsage
 function scheduleUsagePoll() {
   clearTimeout(usageTimer)
   if (auth.isConnected()) usageTimer = setTimeout(pollUsage, usageBackoff)
@@ -656,11 +659,21 @@ async function pollUsage() {
   try {
     const u = await auth.fetchUsage()
     usageBackoff = 5 * 60 * 1000
+    authFails = 0
     pushRealUsage(u)
   } catch (e) {
     if (e && e.status === 429) {
       usageBackoff = Math.min(usageBackoff * 2, 30 * 60 * 1000)
     } else if (e && e.status === 401) {
+      // Refreshing rotates the refresh token, so a request that raced the one
+      // that rotated it comes back rejected while the session is perfectly
+      // alive. Clearing on that first answer throws away a good login, so the
+      // second rejection in a row is what counts.
+      if (++authFails < 2) {
+        usageBackoff = 60 * 1000
+        scheduleUsagePoll()
+        return
+      }
       auth.clear()
       pushRealUsage(null)
       sendAccounts()
@@ -674,7 +687,21 @@ async function pollUsage() {
   scheduleUsagePoll()
 }
 function startUsagePoll() {
+  authFails = 0
   if (auth.isConnected()) pollUsage()
+}
+
+// Waking up: the poll timer was frozen through the sleep, so the numbers on
+// screen are as old as the nap. Re-state what we know — a read that failed on
+// the way down would otherwise leave a stale "log in" panel up — and poll
+// again, after a beat, since the network is rarely back the instant we are.
+function onResume() {
+  if (!auth.isConnected()) return
+  if (win && !win.isDestroyed()) win.webContents.send('auth-state', { connected: true })
+  clearTimeout(usageTimer)
+  usageBackoff = 5 * 60 * 1000
+  usageTimer = setTimeout(pollUsage, 5000)
+  sendProfile()
 }
 
 // push the logged-in account's identity (email + plan) to the renderer

--- a/test/main/main.test.js
+++ b/test/main/main.test.js
@@ -109,7 +109,9 @@ class FakeNotification {
   }
 }
 
+const powerHandlers = new Map()
 const electronMock = {
+  powerMonitor: { on: (ev, cb) => powerHandlers.set(ev, cb) },
   app: {
     whenReady: () => Promise.resolve(),
     getVersion: () => '1.5.0',
@@ -448,8 +450,14 @@ describe('threshold alerts', () => {
     await fire('auth-code', 'code#state') // connected, and a poll is scheduled
     await new Promise((r) => realSetTimeout(r, 5))
     notifications.length = 0
+    const clearedBefore = authState.cleared
     authState.usageError = Object.assign(new Error('dead'), { status: 401 })
     await timers.timeouts.at(-1).fn() // the scheduled poll, now rejected
+    await new Promise((r) => realSetTimeout(r, 5))
+    // one rejection can be a rotated refresh token losing a race: still logged in
+    expect(notifications).toEqual([])
+    expect(authState.cleared).toBe(clearedBefore)
+    await timers.timeouts.at(-1).fn() // the retry, rejected too — now it is real
     await new Promise((r) => realSetTimeout(r, 5))
     expect(notifications.map((n) => n.title)).toContain('Clauddy lost access to your usage')
     authState.usageError = null
@@ -779,6 +787,23 @@ describe('update check', () => {
     } finally {
       Object.defineProperty(process, 'platform', { value: real, configurable: true })
     }
+  })
+})
+
+describe('waking from sleep', () => {
+  test('re-states the connection and polls again', async () => {
+    await fire('auth-code', 'code#state')
+    await new Promise((r) => realSetTimeout(r, 5))
+    sent.length = 0
+    authState.usage = { ...authState.usage, session: { pct: 61, resetMs: 1 } }
+
+    powerHandlers.get('resume')()
+    // the panel may be showing a stale "log in" from a read that failed on the
+    // way down, so the state is restated even though nothing changed
+    expect(lastOf('auth-state')).toEqual({ connected: true })
+    await timers.timeouts.at(-1).fn() // the poll it scheduled
+    await new Promise((r) => realSetTimeout(r, 5))
+    expect(lastOf('real-usage').session.pct).toBe(61)
   })
 })
 

--- a/test/unit/auth.test.js
+++ b/test/unit/auth.test.js
@@ -137,6 +137,18 @@ describe('connection state', () => {
     fs.writeFileSync(TOKEN_PATH, '{ not json')
     expect(auth.isConnected()).toBe(false)
   })
+
+  test('a token that cannot be read still counts as connected', async () => {
+    auth.clear()
+    // a read that fails for anything but "no such file" — the shape of a disk
+    // that is not up yet after a sleep. It must not read as a logout.
+    fs.mkdirSync(TOKEN_PATH, { recursive: true })
+    expect(auth.isConnected()).toBe(true)
+    // …and the poll is told to try later, not to send the user to the browser
+    await expect(auth.fetchUsage()).rejects.toMatchObject({ status: 0 })
+    fs.rmSync(TOKEN_PATH, { recursive: true, force: true })
+    expect(auth.isConnected()).toBe(false)
+  })
 })
 
 describe('usage mapping', () => {


### PR DESCRIPTION
Reported after leaving the app running overnight: every account asked to log in again, and logging into one brought the others back — so the tokens were on disk the whole time and only the state on screen was wrong.

### The token that was there all along

`load()` in `auth.js` treated any failed read as "no token", including a read that failed because the disk was not up yet on wake. `isConnected()` then said `false`, the panel switched to "log in", and since the renderer only repaints on a new `auth-state` it stayed there until something forced another send — which is why logging into one account appeared to bring the rest back.

A read error other than `ENOENT` now keeps the account connected, and makes the poll fail with status `0` — try later — instead of `401`. A file that is present but unparseable still reads as disconnected, as before.

### Two fixes on the same path

- **Waking up.** There was no `powerMonitor` handling at all: the poll timer froze with the machine, so the numbers on screen were as old as the nap and the next attempt was up to 5 minutes away. `resume` now restates the connection and re-polls after 5s, since the network is rarely back the instant we are.
- **A single 401 no longer clears the token.** Refreshing rotates the refresh token, so a request that raced the one that rotated it comes back rejected while the session is perfectly alive — and `auth.clear()` deleted a good login on that first answer. It now takes two rejections in a row.

### Tests

- `test/unit/auth`: a token that cannot be read still counts as connected, and the fetch reports status `0`.
- `test/main`: waking restates the connection and polls again; losing the token takes two consecutive 401s.

`bun run test` 108/68/91 pass · coverage 90.1% · `bun run check` clean · `bun run pack` builds.