### PR TITLE
feat(usage): pull the % as soon as tokens are spent

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Knowing you're at **82%** with **1h 12m** left on the window still leaves you do
 - **`~35m left at this pace`** (in coral) — you'd run out before the window resets. Ease off, or wrap up.
 - **`resets before you run out`** — the reset gets there first. Carry on.
 
-The slope is fitted over your **session tokens** rather than the account %. The % is the number you care about, but it arrives as a whole number every ~5 minutes — over a short window the whole signal is a single `16 → 17` step, which throws the fitted pace off by multiples. Local-log tokens step too — one jump per assistant turn — but in increments some 10–20× finer, so the slope is far steadier; the account % then anchors it, converting tokens into % and re-calibrating on every poll.
+The slope is fitted over your **session tokens** rather than the account %. The % is the number you care about, but it arrives as a whole number every few minutes — over a short window the whole signal is a single `16 → 17` step, which throws the fitted pace off by multiples. Local-log tokens step too — one jump per assistant turn — but in increments some 10–20× finer, so the slope is far steadier; the account % then anchors it, converting tokens into % and re-calibrating on every poll.
 
 It reads your **recent** pace, not the session average: go quiet for a few minutes and the projection eases off, which is the point.
 

--- a/auth.js
+++ b/auth.js
@@ -211,6 +211,24 @@ function scopedWeeks(j) {
   return out
 }
 
+// What the endpoint says its own budget is. Undocumented, so we only ever read
+// it — nothing depends on it yet. Knowing the real numbers is what tells us how
+// close the activity poll's floor can get.
+let rateLimit = null
+function readRateLimit(res) {
+  const out = {}
+  try {
+    for (const [k, v] of res.headers) {
+      if (k.startsWith('anthropic-ratelimit-')) out[k.slice(20)] = v
+    }
+  } catch {
+    return // no headers to read — nothing here is worth failing a fetch over
+  }
+  if (!Object.keys(out).length) return
+  if (JSON.stringify(out) !== JSON.stringify(rateLimit)) console.log('usage rate limit', out)
+  rateLimit = out
+}
+
 // Step 3: fetch the authoritative usage
 async function fetchUsage() {
   const token = await validToken()
@@ -228,6 +246,7 @@ async function fetchUsage() {
       status: res.status,
     })
   }
+  readRateLimit(res)
   const j = await res.json()
   return {
     session: win(j.five_hour) || { pct: 0, resetMs: null },
@@ -261,4 +280,13 @@ async function fetchProfile() {
   return profile
 }
 
-module.exports = { begin, complete, fetchUsage, fetchProfile, clear, isConnected, setDataDir }
+module.exports = {
+  rateLimit: () => rateLimit,
+  begin,
+  complete,
+  fetchUsage,
+  fetchProfile,
+  clear,
+  isConnected,
+  setDataDir,
+}

--- a/main.js
+++ b/main.js
@@ -234,6 +234,7 @@ function applyAccount(acc) {
   usage.setClaudeDir(acc.claudeDir)
   armed = new Set()
   lastSessionPct = null
+  lastSeenTokens = null // the new account's first read is a baseline, not a spend
   loadAlertState()
 }
 
@@ -402,6 +403,7 @@ function createWindow() {
       const data = getUsage(config)
       win.webContents.send('usage', data)
       checkAlerts(config, data)
+      onLocalActivity(data)
     } catch (err) {
       win.webContents.send('usage-error', String(err))
     }
@@ -651,11 +653,32 @@ function watchDebug() {
 let usageTimer = null
 let usageBackoff = 5 * 60 * 1000
 let authFails = 0 // consecutive 401s — see pollUsage
+let lastPollAt = 0
+
+// The authoritative % only moves when tokens are actually spent, and the local
+// logs show that within a tick. Polling off that beats a faster clock: it
+// answers while the user is working and asks for nothing while they are not.
+// The floor is what bounds the cost — never more than one call per 90s, well
+// under what a fixed one-minute poll would spend.
+const POLL_FLOOR_MS = 90 * 1000
+let lastSeenTokens = null
+function onLocalActivity(data) {
+  const t = data?.session?.tokens
+  if (typeof t !== 'number') return
+  const grew = lastSeenTokens != null && t > lastSeenTokens
+  lastSeenTokens = t
+  if (!grew || !auth.isConnected()) return
+  if (Date.now() - lastPollAt < POLL_FLOOR_MS) return
+  clearTimeout(usageTimer) // pollUsage schedules the next heartbeat itself
+  pollUsage()
+}
+
 function scheduleUsagePoll() {
   clearTimeout(usageTimer)
   if (auth.isConnected()) usageTimer = setTimeout(pollUsage, usageBackoff)
 }
 async function pollUsage() {
+  lastPollAt = Date.now()
   try {
     const u = await auth.fetchUsage()
     usageBackoff = 5 * 60 * 1000

--- a/test/main/main.test.js
+++ b/test/main/main.test.js
@@ -185,6 +185,7 @@ const authState = {
   profile: { email: 'a@b.com', name: 'Ana', plan: 'Max' },
   completeError: null,
   cleared: 0,
+  usageCalls: 0,
 }
 
 mock.module('../../usage.js', () => ({
@@ -213,6 +214,7 @@ mock.module('../../auth.js', () => ({
     authState.connected = true
   },
   fetchUsage: async () => {
+    authState.usageCalls++
     if (authState.usageError) throw authState.usageError
     return authState.usage
   },
@@ -787,6 +789,45 @@ describe('update check', () => {
     } finally {
       Object.defineProperty(process, 'platform', { value: real, configurable: true })
     }
+  })
+})
+
+describe('polling off local activity', () => {
+  const realNow = Date.now
+  // the floor is measured against the clock, so the test has to move it
+  const spend = async (tokens, secondsLater = 0) => {
+    Date.now = () => realNow() + secondsLater * 1000
+    usageData = { ...usageData, session: { ...usageData.session, tokens } }
+    tick()
+    await new Promise((r) => realSetTimeout(r, 5))
+    Date.now = realNow
+  }
+
+  test('tokens spent locally pull the authoritative % right away', async () => {
+    await fire('auth-code', 'code#state')
+    await new Promise((r) => realSetTimeout(r, 5))
+    await spend(1000) // the first read is only a baseline
+    const calls = authState.usageCalls
+
+    authState.usage = { ...DEFAULT_USAGE, session: { pct: 77, resetMs: 1000 } }
+    await spend(2000, 200)
+    expect(authState.usageCalls).toBe(calls + 1)
+    expect(lastOf('real-usage').session.pct).toBe(77)
+  })
+
+  test('a second spend inside the floor waits its turn', async () => {
+    const calls = authState.usageCalls
+    await spend(3000, 210)
+    expect(authState.usageCalls).toBe(calls)
+  })
+
+  test('a tick that spent nothing asks for nothing', async () => {
+    const calls = authState.usageCalls
+    Date.now = () => realNow() + 900 * 1000
+    tick()
+    await new Promise((r) => realSetTimeout(r, 5))
+    Date.now = realNow
+    expect(authState.usageCalls).toBe(calls)
   })
 })
 


### PR DESCRIPTION
The authoritative session % came in on a fixed five-minute clock, so it lagged behind what the user had just done — the common complaint being that the numbers feel stale.

Raising the frequency was the obvious move and the wrong one: the endpoint is undocumented and rate-limited, and our own backoff doubles to 30 minutes on a 429, so a one-minute clock can end up slower than the five-minute one it replaced. It is also the same credential the user's Claude Code session runs on.

### Polling off activity instead

The % only moves when tokens are actually spent, and the local logs see that within a 4s tick. So the poll now follows the spend: it answers while the user is working and asks for nothing while they are not — fewer calls than today on average, since an idle machine polls only on the heartbeat.

- a 90s floor bounds the worst case well below what a one-minute clock would spend
- the five-minute poll stays as the heartbeat, because the window can also reset with no local activity at all and that has to be noticed too
- an account switch resets the baseline, so the first read after it is not mistaken for a spend

No new setting. The interval stays an implementation detail rather than a number the user has to guess at.

### Measuring, while we are here

`fetchUsage` now reads the `anthropic-ratelimit-*` headers the endpoint already returns and we were throwing away, and logs them when they change. Nothing depends on them — knowing the real budget is what would let the floor come down later.

### Tests

`test/main`: tokens spent locally pull the % right away; a second spend inside the floor waits its turn; a tick that spent nothing asks for nothing.

`bun run test` 108/71/91 pass · coverage 90.1% · `bun run check` clean · `bun run pack` builds.